### PR TITLE
Brand icons, form polish, one-off fixes

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
+        "@icons-pack/react-simple-icons": "^13.11.1",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-alert-dialog": "^1.1.14",
         "@radix-ui/react-aspect-ratio": "^1.1.7",
@@ -844,6 +845,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@icons-pack/react-simple-icons": {
+      "version": "13.11.1",
+      "resolved": "https://registry.npmjs.org/@icons-pack/react-simple-icons/-/react-simple-icons-13.11.1.tgz",
+      "integrity": "sha512-WbwN/o7dUHEjDCJh2p3RvDZ4kZ8nhfUSkUSm0bWuPTXIsoKgDJpwD5UkMCG22R/5kZH6lHAZXwuHWsKNtX7fYA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.13 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
+    "@icons-pack/react-simple-icons": "^13.11.1",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-aspect-ratio": "^1.1.7",

--- a/frontend/src/components/expenses/AllTabBlockView.tsx
+++ b/frontend/src/components/expenses/AllTabBlockView.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { ChevronDown, ChevronRight, Home, Repeat, Shield, Pencil, AlertTriangle, Sparkles, User, Car, Baby, PawPrint, Box, Plus } from "lucide-react";
 import { CatIcon } from "@/components/ui/cat-icon";
+import { ServiceIcon } from "@/components/ui/service-icon";
 import { Money } from "@/components/ui/money";
 import { MoneyInput } from "@/components/ui/money-input";
 import { RowItem } from "@/components/ui/row-item";
@@ -203,7 +204,16 @@ export const ExpenseBlock = ({
                                 className={`group ${item.inactive ? "opacity-50" : ""}`}
                             >
                                 <div className="flex items-center gap-3 min-w-0 flex-1">
-                                    <CatIcon icon={Icon || Sparkles} hue={cat?.hue} size={32} />
+                                    {categoryType === 'subscription' ? (
+                                        <ServiceIcon
+                                            serviceName={item.name}
+                                            fallbackIcon={Icon || Sparkles}
+                                            fallbackHue={cat?.hue}
+                                            size={32}
+                                        />
+                                    ) : (
+                                        <CatIcon icon={Icon || Sparkles} hue={cat?.hue} size={32} />
+                                    )}
                                     <div className="flex items-center gap-2 min-w-0 flex-wrap">
                                         <span className={`font-medium text-sm sm:text-base truncate ${item.billingCycle === 'monthly' || !item.billingCycle || item.isDue
                                             ? 'text-ink'

--- a/frontend/src/components/expenses/TemporaryExpenseFormDialog.tsx
+++ b/frontend/src/components/expenses/TemporaryExpenseFormDialog.tsx
@@ -9,19 +9,22 @@ import {
 } from "@/components/ui/select";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
-import { useEncryptedFields, temporaryExpenseFields } from "@/hooks/useEncryptedFields";
-import { getCurrentFinancialMonth } from "@/utils/dateUtils";
+import { useEncryptedFields, monthlyExpenseFields } from "@/hooks/useEncryptedFields";
+import { getCurrentFinancialMonth, getFinancialMonthRange } from "@/utils/dateUtils";
+import { format } from "date-fns";
 import { FormDialogFooter } from "@/components/shared/FormDialogFooter";
 import { FormField, FormRow } from "@/components/shared/FormField";
 import { useEntityForm } from "@/hooks/useEntityForm";
 
+import { Wrench, Heart, Hammer, Gift, Plane, MoreHorizontal } from "lucide-react";
+
 const temporaryCategories = [
-    { value: "car_repair", label: "Car repair" },
-    { value: "medical", label: "Medical" },
-    { value: "home_repair", label: "Home repair" },
-    { value: "gift", label: "Gift" },
-    { value: "travel", label: "Travel" },
-    { value: "other", label: "Other" },
+    { value: "car_repair", label: "Car repair", icon: Wrench },
+    { value: "medical", label: "Medical", icon: Heart },
+    { value: "home_repair", label: "Home repair", icon: Hammer },
+    { value: "gift", label: "Gift", icon: Gift },
+    { value: "travel", label: "Travel", icon: Plane },
+    { value: "other", label: "Other", icon: MoreHorizontal },
 ];
 
 interface TemporaryExpenseFormDialogProps {
@@ -43,7 +46,7 @@ export const TemporaryExpenseFormDialog = ({
     open, onOpenChange, householdId, financialMonthStart, onSuccess,
 }: TemporaryExpenseFormDialogProps) => {
     const { user } = useAuth();
-    const { encryptRecord } = useEncryptedFields(temporaryExpenseFields);
+    const { encryptRecord } = useEncryptedFields(monthlyExpenseFields);
     const [pristine, setPristine] = useState(blank());
     const [formData, setFormData] = useState(pristine);
 
@@ -62,17 +65,22 @@ export const TemporaryExpenseFormDialog = ({
         isEdit: false,
         save: async () => {
             if (!user) throw new Error("Not authenticated");
+            const month = getCurrentFinancialMonth(financialMonthStart);
+            const { start, end } = getFinancialMonthRange(month, financialMonthStart);
             const baseData = {
                 household_id: householdId,
-                month: getCurrentFinancialMonth(financialMonthStart),
-                description: formData.description.trim(),
-                category: formData.category,
+                expense_id: null,
+                month,
+                month_start: format(start, "yyyy-MM-dd"),
+                month_end: format(end, "yyyy-MM-dd"),
+                one_time_name: formData.description.trim(),
+                one_time_category: formData.category,
                 amount: parseFloat(formData.amount),
                 notes: formData.notes || null,
                 created_by: user.id,
             };
             const data = await encryptRecord(baseData);
-            const { error } = await supabase.from("temporary_expenses").insert(data);
+            const { error } = await supabase.from("monthly_expenses").insert(data as any);
             if (error) throw error;
         },
         onSaved: () => {
@@ -88,9 +96,9 @@ export const TemporaryExpenseFormDialog = ({
         <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogContent>
                 <DialogHeader>
-                    <DialogTitle>One-time expense</DialogTitle>
+                    <DialogTitle>Add one-off expense</DialogTitle>
                     <DialogDescription>
-                        A single, unexpected cost — car repair, medical bill, gift, etc. Tracked just for this month.
+                        A one-time cost outside your regular budget — car repair, medical bill, gift, travel, etc.
                     </DialogDescription>
                 </DialogHeader>
 
@@ -116,9 +124,17 @@ export const TemporaryExpenseFormDialog = ({
                             <Select value={formData.category} onValueChange={(v) => setFormData({ ...formData, category: v })}>
                                 <SelectTrigger><SelectValue /></SelectTrigger>
                                 <SelectContent>
-                                    {temporaryCategories.map((cat) => (
-                                        <SelectItem key={cat.value} value={cat.value}>{cat.label}</SelectItem>
-                                    ))}
+                                    {temporaryCategories.map((cat) => {
+                                        const Icon = cat.icon;
+                                        return (
+                                            <SelectItem key={cat.value} value={cat.value}>
+                                                <div className="flex items-center gap-2">
+                                                    <Icon className="h-4 w-4" />
+                                                    <span>{cat.label}</span>
+                                                </div>
+                                            </SelectItem>
+                                        );
+                                    })}
                                 </SelectContent>
                             </Select>
                         </FormField>

--- a/frontend/src/components/expenses/forms/InsuranceForm.tsx
+++ b/frontend/src/components/expenses/forms/InsuranceForm.tsx
@@ -14,17 +14,7 @@ import { FormDialogFooter } from "@/components/shared/FormDialogFooter";
 import { FormField, FormRow } from "@/components/shared/FormField";
 import { useEntityForm } from "@/hooks/useEntityForm";
 
-const insuranceTypes = [
-    { value: "home", label: "Home Insurance" },
-    { value: "car", label: "Car Insurance" },
-    { value: "health", label: "Health Insurance" },
-    { value: "child", label: "Child Insurance" },
-    { value: "life", label: "Life Insurance" },
-    { value: "pet", label: "Pet Insurance" },
-    { value: "travel", label: "Travel Insurance" },
-    { value: "liability", label: "Liability Insurance" },
-    { value: "other", label: "Other" },
-];
+import { insuranceTypes } from "@/constants/insuranceTypes";
 
 const monthNames = [
     "January", "February", "March", "April", "May", "June",
@@ -164,17 +154,33 @@ export const InsuranceForm = ({
                             {usedTypes.length > 0 && (
                                 <SelectGroup>
                                     <SelectLabel>Used in this household</SelectLabel>
-                                    {usedTypes.map((t) => (
-                                        <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>
-                                    ))}
+                                    {usedTypes.map((t) => {
+                                        const Icon = t.icon;
+                                        return (
+                                            <SelectItem key={t.value} value={t.value}>
+                                                <div className="flex items-center gap-2">
+                                                    {Icon && <Icon className="h-4 w-4" />}
+                                                    <span>{t.label}</span>
+                                                </div>
+                                            </SelectItem>
+                                        );
+                                    })}
                                 </SelectGroup>
                             )}
                             {moreTypes.length > 0 && (
                                 <SelectGroup>
                                     <SelectLabel>{usedTypes.length > 0 ? "More types" : "All types"}</SelectLabel>
-                                    {moreTypes.map((t) => (
-                                        <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>
-                                    ))}
+                                    {moreTypes.map((t) => {
+                                        const Icon = t.icon;
+                                        return (
+                                            <SelectItem key={t.value} value={t.value}>
+                                                <div className="flex items-center gap-2">
+                                                    {Icon && <Icon className="h-4 w-4" />}
+                                                    <span>{t.label}</span>
+                                                </div>
+                                            </SelectItem>
+                                        );
+                                    })}
                                 </SelectGroup>
                             )}
                         </SelectContent>

--- a/frontend/src/components/expenses/forms/SubscriptionForm.tsx
+++ b/frontend/src/components/expenses/forms/SubscriptionForm.tsx
@@ -142,17 +142,33 @@ export const SubscriptionForm = ({
                             {usedCats.length > 0 && (
                                 <SelectGroup>
                                     <SelectLabel>Used in this household</SelectLabel>
-                                    {usedCats.map((cat) => (
-                                        <SelectItem key={cat.value} value={cat.value}>{cat.label}</SelectItem>
-                                    ))}
+                                    {usedCats.map((cat) => {
+                                        const Icon = cat.icon;
+                                        return (
+                                            <SelectItem key={cat.value} value={cat.value}>
+                                                <div className="flex items-center gap-2">
+                                                    {Icon && <Icon className="h-4 w-4" />}
+                                                    <span>{cat.label}</span>
+                                                </div>
+                                            </SelectItem>
+                                        );
+                                    })}
                                 </SelectGroup>
                             )}
                             {moreCats.length > 0 && (
                                 <SelectGroup>
                                     <SelectLabel>{usedCats.length > 0 ? "More categories" : "All categories"}</SelectLabel>
-                                    {moreCats.map((cat) => (
-                                        <SelectItem key={cat.value} value={cat.value}>{cat.label}</SelectItem>
-                                    ))}
+                                    {moreCats.map((cat) => {
+                                        const Icon = cat.icon;
+                                        return (
+                                            <SelectItem key={cat.value} value={cat.value}>
+                                                <div className="flex items-center gap-2">
+                                                    {Icon && <Icon className="h-4 w-4" />}
+                                                    <span>{cat.label}</span>
+                                                </div>
+                                            </SelectItem>
+                                        );
+                                    })}
                                 </SelectGroup>
                             )}
                         </SelectContent>

--- a/frontend/src/components/income/IncomeFormDialog.tsx
+++ b/frontend/src/components/income/IncomeFormDialog.tsx
@@ -22,12 +22,14 @@ import { FormDialogFooter } from "@/components/shared/FormDialogFooter";
 import { FormField, FormRow } from "@/components/shared/FormField";
 import { useEntityForm } from "@/hooks/useEntityForm";
 
+import { Briefcase, TrendingUp, HandCoins, PiggyBank, MoreHorizontal } from "lucide-react";
+
 const INCOME_CATEGORIES = [
-    { value: "salary", label: "Salary" },
-    { value: "business_income", label: "Business income" },
-    { value: "government_benefits", label: "Government benefits" },
-    { value: "investment_income", label: "Investment income" },
-    { value: "other", label: "Other" },
+    { value: "salary", label: "Salary", icon: Briefcase },
+    { value: "business_income", label: "Business income", icon: PiggyBank },
+    { value: "government_benefits", label: "Government benefits", icon: HandCoins },
+    { value: "investment_income", label: "Investment income", icon: TrendingUp },
+    { value: "other", label: "Other", icon: MoreHorizontal },
 ] as const;
 
 type IncomeCategory = typeof INCOME_CATEGORIES[number]["value"];
@@ -188,9 +190,17 @@ export const IncomeFormDialog = ({
                             >
                                 <SelectTrigger><SelectValue /></SelectTrigger>
                                 <SelectContent>
-                                    {INCOME_CATEGORIES.map(c => (
-                                        <SelectItem key={c.value} value={c.value}>{c.label}</SelectItem>
-                                    ))}
+                                    {INCOME_CATEGORIES.map(c => {
+                                        const Icon = c.icon;
+                                        return (
+                                            <SelectItem key={c.value} value={c.value}>
+                                                <div className="flex items-center gap-2">
+                                                    <Icon className="h-4 w-4" />
+                                                    <span>{c.label}</span>
+                                                </div>
+                                            </SelectItem>
+                                        );
+                                    })}
                                 </SelectContent>
                             </Select>
                         </FormField>

--- a/frontend/src/components/income/OneTimeIncomeDialog.tsx
+++ b/frontend/src/components/income/OneTimeIncomeDialog.tsx
@@ -6,7 +6,7 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
-import { Gift } from "lucide-react";
+import { Gift, Ticket, Receipt, Star, Tag, Crown, MoreHorizontal } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
 import { useHousehold } from "@/contexts/HouseholdContext";
@@ -15,13 +15,13 @@ import { useEncryptedFields, monthlyIncomeFields } from "@/hooks/useEncryptedFie
 import { getCurrentFinancialMonth, getFinancialMonthRange } from "@/utils/dateUtils";
 
 const oneTimeCategories = [
-    { value: "gift", label: "Gift Money" },
-    { value: "lottery", label: "Lottery/Winnings" },
-    { value: "tax_refund", label: "Tax Refund" },
-    { value: "bonus", label: "Bonus Payment" },
-    { value: "sale", label: "Sale of Items" },
-    { value: "inheritance", label: "Inheritance" },
-    { value: "other", label: "Other" },
+    { value: "gift", label: "Gift Money", icon: Gift },
+    { value: "lottery", label: "Lottery/Winnings", icon: Ticket },
+    { value: "tax_refund", label: "Tax Refund", icon: Receipt },
+    { value: "bonus", label: "Bonus Payment", icon: Star },
+    { value: "sale", label: "Sale of Items", icon: Tag },
+    { value: "inheritance", label: "Inheritance", icon: Crown },
+    { value: "other", label: "Other", icon: MoreHorizontal },
 ];
 
 interface OneTimeIncomeDialogProps {
@@ -98,9 +98,9 @@ export const OneTimeIncomeDialog = ({ householdId, onSuccess }: OneTimeIncomeDia
             </DialogTrigger>
             <DialogContent>
                 <DialogHeader>
-                    <DialogTitle>Add One-Time Income</DialogTitle>
+                    <DialogTitle>Add one-off income</DialogTitle>
                     <DialogDescription>
-                        Record a one-time income like gift money, lottery winnings, or tax refund
+                        A one-time inflow outside your regular sources — gift, refund, bonus, sale, etc.
                     </DialogDescription>
                 </DialogHeader>
                 <div className="space-y-4">
@@ -111,11 +111,17 @@ export const OneTimeIncomeDialog = ({ householdId, onSuccess }: OneTimeIncomeDia
                                 <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
-                                {oneTimeCategories.map((cat) => (
-                                    <SelectItem key={cat.value} value={cat.value}>
-                                        {cat.label}
-                                    </SelectItem>
-                                ))}
+                                {oneTimeCategories.map((cat) => {
+                                    const Icon = cat.icon;
+                                    return (
+                                        <SelectItem key={cat.value} value={cat.value}>
+                                            <div className="flex items-center gap-2">
+                                                <Icon className="h-4 w-4" />
+                                                <span>{cat.label}</span>
+                                            </div>
+                                        </SelectItem>
+                                    );
+                                })}
                             </SelectContent>
                         </Select>
                     </div>

--- a/frontend/src/components/shared/FormField.tsx
+++ b/frontend/src/components/shared/FormField.tsx
@@ -17,10 +17,12 @@ export const FormField = ({
     <div className={cn("space-y-1.5", className)}>
         <Label htmlFor={htmlFor}>
             {label}
-            {optional && (
+            {optional ? (
                 <span className="text-xs text-muted-foreground font-normal ml-1">
                     ({optionalNote ?? "optional"})
                 </span>
+            ) : (
+                <span className="text-destructive ml-0.5" aria-hidden="true">*</span>
             )}
         </Label>
         {children}

--- a/frontend/src/components/ui/service-icon.tsx
+++ b/frontend/src/components/ui/service-icon.tsx
@@ -1,0 +1,40 @@
+import { LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { CatIcon } from "./cat-icon";
+import { matchBrandIcon } from "@/constants/brandIcons";
+
+interface ServiceIconProps {
+    /** Service / brand name to look up in the brand registry. */
+    serviceName?: string | null;
+    /** Fallback icon when no brand match (the category icon). */
+    fallbackIcon: LucideIcon;
+    /** Hue for the fallback CatIcon. */
+    fallbackHue?: number;
+    size?: number;
+    className?: string;
+}
+
+export const ServiceIcon = ({
+    serviceName, fallbackIcon, fallbackHue, size = 36, className,
+}: ServiceIconProps) => {
+    const brand = matchBrandIcon(serviceName);
+
+    if (!brand) {
+        return <CatIcon icon={fallbackIcon} hue={fallbackHue} size={size} className={className} />;
+    }
+
+    const { Icon, hex } = brand;
+    return (
+        <div
+            className={cn("flex items-center justify-center shrink-0", className)}
+            style={{
+                width: size,
+                height: size,
+                borderRadius: Math.round(size * 0.32),
+                background: hex,
+            }}
+        >
+            <Icon size={Math.round(size * 0.5)} color="#ffffff" />
+        </div>
+    );
+};

--- a/frontend/src/constants/brandIcons.tsx
+++ b/frontend/src/constants/brandIcons.tsx
@@ -1,0 +1,86 @@
+import {
+    SiNetflix, SiSpotify, SiYoutube, SiAppletv, SiApplemusic,
+    SiHbo, SiHbomax, SiTwitch, SiCrunchyroll, SiAudible,
+    SiAnthropic, SiGithub, SiNotion,
+    Si1password, SiBitwarden, SiDiscord, SiZoom,
+    SiDropbox, SiIcloud, SiGooglecloud, SiNordvpn, SiExpressvpn,
+    SiDuolingo, SiHeadspace, SiPatreon, SiSubstack,
+    SiGoogleplay, SiPlaystation, SiSteam,
+} from "@icons-pack/react-simple-icons";
+
+export interface BrandIcon {
+    Icon: React.ComponentType<{ size?: string | number; color?: string; title?: string }>;
+    hex: string;
+}
+
+const REGISTRY: Record<string, BrandIcon> = {
+    netflix:      { Icon: SiNetflix,     hex: "#E50914" },
+    spotify:      { Icon: SiSpotify,     hex: "#1DB954" },
+    youtube:      { Icon: SiYoutube,     hex: "#FF0000" },
+    appletv:      { Icon: SiAppletv,     hex: "#000000" },
+    applemusic:   { Icon: SiApplemusic,  hex: "#FA243C" },
+    hbo:          { Icon: SiHbo,         hex: "#000000" },
+    hbomax:       { Icon: SiHbomax,      hex: "#002BE7" },
+    max:          { Icon: SiHbomax,      hex: "#002BE7" },
+    twitch:       { Icon: SiTwitch,      hex: "#9146FF" },
+    crunchyroll:  { Icon: SiCrunchyroll, hex: "#F47521" },
+    audible:      { Icon: SiAudible,     hex: "#F8991C" },
+
+    claude:       { Icon: SiAnthropic,   hex: "#D97757" },
+    anthropic:    { Icon: SiAnthropic,   hex: "#D97757" },
+
+    github:       { Icon: SiGithub,      hex: "#181717" },
+    githubcopilot:{ Icon: SiGithub,      hex: "#181717" },
+    notion:       { Icon: SiNotion,      hex: "#000000" },
+    onepassword:  { Icon: Si1password,   hex: "#0094F5" },
+    "1password":  { Icon: Si1password,   hex: "#0094F5" },
+    bitwarden:    { Icon: SiBitwarden,   hex: "#175DDC" },
+    discord:      { Icon: SiDiscord,     hex: "#5865F2" },
+    zoom:         { Icon: SiZoom,        hex: "#0B5CFF" },
+
+    dropbox:      { Icon: SiDropbox,     hex: "#0061FF" },
+    icloud:       { Icon: SiIcloud,      hex: "#3693F3" },
+    googlecloud:  { Icon: SiGooglecloud, hex: "#4285F4" },
+    googleone:    { Icon: SiGooglecloud, hex: "#4285F4" },
+
+    nordvpn:      { Icon: SiNordvpn,     hex: "#4687FF" },
+    expressvpn:   { Icon: SiExpressvpn,  hex: "#DA3940" },
+
+    duolingo:     { Icon: SiDuolingo,    hex: "#58CC02" },
+    headspace:    { Icon: SiHeadspace,   hex: "#F47D31" },
+
+    patreon:      { Icon: SiPatreon,     hex: "#FF424D" },
+    substack:     { Icon: SiSubstack,    hex: "#FF6719" },
+    googleplay:   { Icon: SiGoogleplay,  hex: "#414141" },
+    playstation:  { Icon: SiPlaystation, hex: "#003791" },
+    steam:        { Icon: SiSteam,       hex: "#000000" },
+};
+
+const TIER_WORDS = new Set([
+    "premium", "pro", "max", "plus", "family", "duo", "free",
+    "basic", "standard", "ultra", "lite", "starter", "essential", "personal",
+]);
+
+export function matchBrandIcon(serviceName: string | null | undefined): BrandIcon | null {
+    if (!serviceName) return null;
+    const cleaned = serviceName
+        .toLowerCase()
+        .replace(/\+/g, "")
+        .replace(/[^a-z0-9 ]/g, "")
+        .trim();
+    if (!cleaned) return null;
+
+    const collapsed = cleaned.replace(/\s+/g, "");
+    if (REGISTRY[collapsed]) return REGISTRY[collapsed];
+
+    const firstMeaningful = cleaned
+        .split(/\s+/)
+        .filter(w => !TIER_WORDS.has(w))
+        .join("");
+    if (firstMeaningful && REGISTRY[firstMeaningful]) return REGISTRY[firstMeaningful];
+
+    const firstWord = cleaned.split(/\s+/)[0];
+    if (REGISTRY[firstWord]) return REGISTRY[firstWord];
+
+    return null;
+}

--- a/frontend/src/integrations/supabase/types.ts
+++ b/frontend/src/integrations/supabase/types.ts
@@ -653,7 +653,7 @@ export type Database = {
           electricity_market: number | null
           encrypted_actual_amount: string | null
           encrypted_budget_amount: string | null
-          expense_id: string
+          expense_id: string | null
           household_id: string
           id: string
           is_encrypted: boolean | null
@@ -661,6 +661,8 @@ export type Database = {
           month_end: string | null
           month_start: string | null
           notes: string | null
+          one_time_category: string | null
+          one_time_name: string | null
           updated_at: string | null
         }
         Insert: {
@@ -670,7 +672,7 @@ export type Database = {
           electricity_market?: number | null
           encrypted_actual_amount?: string | null
           encrypted_budget_amount?: string | null
-          expense_id: string
+          expense_id?: string | null
           household_id: string
           id?: string
           is_encrypted?: boolean | null
@@ -678,6 +680,8 @@ export type Database = {
           month_end?: string | null
           month_start?: string | null
           notes?: string | null
+          one_time_category?: string | null
+          one_time_name?: string | null
           updated_at?: string | null
         }
         Update: {
@@ -687,7 +691,7 @@ export type Database = {
           electricity_market?: number | null
           encrypted_actual_amount?: string | null
           encrypted_budget_amount?: string | null
-          expense_id?: string
+          expense_id?: string | null
           household_id?: string
           id?: string
           is_encrypted?: boolean | null
@@ -695,6 +699,8 @@ export type Database = {
           month_end?: string | null
           month_start?: string | null
           notes?: string | null
+          one_time_category?: string | null
+          one_time_name?: string | null
           updated_at?: string | null
         }
         Relationships: [

--- a/frontend/src/pages/Overview.tsx
+++ b/frontend/src/pages/Overview.tsx
@@ -20,7 +20,7 @@ import { MonthlyReviewWizard, useMonthlyReviewStatus } from "@/components/dashbo
 import { HouseholdSetupWizard } from "@/components/dashboard/HouseholdSetupWizard";
 import {
   HandCoins, Wallet, Repeat, Shield, ClipboardCheck,
-  ChevronRight, ChevronLeft, Users, Sparkles, CalendarPlus, Loader2,
+  ChevronRight, ChevronLeft, Users, Sparkles, CalendarPlus, Loader2, Zap,
 } from "lucide-react";
 import { planMonth } from "@/services/monthlyPlanning";
 import { toast } from "sonner";
@@ -42,9 +42,9 @@ import { useEarliestDataMonth } from "@/hooks/useEarliestDataMonth";
 
 interface ActivityItem {
   id: string;
-  kind: "shared" | "one_time_income";
+  kind: "shared" | "one_time_income" | "one_time_expense";
   name: string;
-  amount: number; // signed: negative = outflow (shared expense), positive = inflow (income)
+  amount: number; // signed: negative = outflow, positive = inflow
   when: Date;
 }
 
@@ -296,6 +296,15 @@ const Dashboard = () => {
             kind: "one_time_income" as const,
             name: m.one_time_name,
             amount: parseFloat(m.amount) || 0,
+            when: new Date(m.created_at),
+          })),
+        ...decryptedExpenses
+          .filter((m: any) => m.expense_id == null && m.one_time_name)
+          .map((m: any) => ({
+            id: m.id,
+            kind: "one_time_expense" as const,
+            name: m.one_time_name,
+            amount: -(parseFloat(m.amount) || 0),
             when: new Date(m.created_at),
           })),
       ]
@@ -616,6 +625,8 @@ const Dashboard = () => {
                     <div className="w-9 h-9 rounded-lg bg-surface-2 flex items-center justify-center text-ink-2 shrink-0">
                       {item.kind === "shared" ? (
                         <Users className="h-4 w-4" />
+                      ) : item.kind === "one_time_expense" ? (
+                        <Zap className="h-4 w-4" />
                       ) : (
                         <Sparkles className="h-4 w-4" />
                       )}
@@ -623,7 +634,9 @@ const Dashboard = () => {
                     <div className="flex-1 min-w-0">
                       <p className="text-sm font-medium text-ink truncate">{item.name}</p>
                       <p className="text-xs text-muted-foreground">
-                        {item.kind === "shared" ? "Shared expense" : "One-time income"}
+                        {item.kind === "shared" ? "Shared expense"
+                          : item.kind === "one_time_expense" ? "One-off expense"
+                          : "One-off income"}
                         {" · "}
                         {formatRelative(item.when)}
                       </p>

--- a/supabase/migrations/20260511240000_monthly_expenses_one_time.sql
+++ b/supabase/migrations/20260511240000_monthly_expenses_one_time.sql
@@ -1,0 +1,11 @@
+-- One-off expenses live in monthly_expenses with expense_id NULL and
+-- one_time_name + one_time_category populated. Mirrors monthly_incomes.
+-- TemporaryExpenseFormDialog previously wrote to the orphan temporary_expenses
+-- table; this lets the same data show up on Dashboard's activity feed.
+
+ALTER TABLE public.monthly_expenses
+    ADD COLUMN IF NOT EXISTS one_time_name text,
+    ADD COLUMN IF NOT EXISTS one_time_category text;
+
+ALTER TABLE public.monthly_expenses
+    ALTER COLUMN expense_id DROP NOT NULL;


### PR DESCRIPTION
## Summary

- Brand SVG icons in subscription list for ~25 known services. Issue #40 tracks expanding coverage.
- One-off expense dialog wrote to an orphan table; now writes to monthly_expenses and surfaces in Dashboard activity feed.
- Red asterisks on required form fields.
- Aligned one-off dialog title/description copy.
- Category icons render inside the Subscription / Insurance / Income / One-off dropdowns.

## Test plan

- [ ] Subscriptions list shows brand SVG for matched services, category icon for the rest.
- [ ] Add a one-off expense → appears in Dashboard "Recent activity".
- [ ] Open any form — required fields have a red asterisk, optional fields show "(optional)".
- [ ] Open category dropdowns — each option shows its icon next to the label.