### PR TITLE
Multi-user encryption + soft-exit flow + UX polish

### DIFF
--- a/frontend/src/components/DesktopNav.tsx
+++ b/frontend/src/components/DesktopNav.tsx
@@ -72,7 +72,7 @@ const DesktopNav = () => {
               onClick={() => navigate("/settings")}
               variant="ghost"
               size="icon"
-              className="h-8 w-8 shrink-0"
+              className="h-8 w-8 shrink-0 hover:bg-accent-tint hover:text-accent-dk"
               aria-label="Settings"
               title="Settings"
             >

--- a/frontend/src/components/JoinHouseholdWizard.tsx
+++ b/frontend/src/components/JoinHouseholdWizard.tsx
@@ -9,7 +9,6 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useToast } from "@/hooks/use-toast";
 import { Check, Users, ArrowRight, ArrowLeft } from "lucide-react";
 import { PLACEHOLDERS } from "@/constants/ui";
-import { isEmailAllowed } from "@/config/emailWhitelist";
 import { passwordSchema } from "@/config/passwordSchema";
 
 interface JoinHouseholdWizardProps {
@@ -127,15 +126,8 @@ export const JoinHouseholdWizard = ({ open, onOpenChange }: JoinHouseholdWizardP
             return;
         }
 
-        const isAllowed = await isEmailAllowed(email);
-        if (!isAllowed) {
-            toast({
-                title: "Access Restricted",
-                description: "This application is currently in private beta. Your email is not on the approved list.",
-                variant: "destructive",
-            });
-            return;
-        }
+        // Invite IS the authorization here — don't double-gate behind the
+        // whitelist that's meant for unsolicited signups.
 
         if (password !== confirmPassword) {
             toast({

--- a/frontend/src/components/JoinHouseholdWizard.tsx
+++ b/frontend/src/components/JoinHouseholdWizard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -6,8 +6,10 @@ import { Label } from "@/components/ui/label";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
+import { useEncryption } from "@/contexts/EncryptionContext";
+import { useHousehold } from "@/contexts/HouseholdContext";
 import { useToast } from "@/hooks/use-toast";
-import { Check, Users, ArrowRight, ArrowLeft } from "lucide-react";
+import { Check, Users, ArrowRight, ArrowLeft, Loader2 } from "lucide-react";
 import { PLACEHOLDERS } from "@/constants/ui";
 import { passwordSchema } from "@/config/passwordSchema";
 
@@ -16,21 +18,27 @@ interface JoinHouseholdWizardProps {
     onOpenChange: (open: boolean) => void;
 }
 
+type JoinPhase =
+    | { kind: "idle" }
+    | { kind: "joining"; message: string }
+    | { kind: "settling"; expected: { userId: string; householdId: string } }
+    | { kind: "error"; message: string };
+
 export const JoinHouseholdWizard = ({ open, onOpenChange }: JoinHouseholdWizardProps) => {
-    const { signUpAndJoinHousehold } = useAuth();
+    const { user, signUpAndJoinHousehold } = useAuth();
+    const { setupVaultFromInvite, isUnlocked } = useEncryption();
+    const { household: activeHousehold, refresh: refreshHousehold } = useHousehold();
     const { toast } = useToast();
 
     const [step, setStep] = useState(1);
     const [loading, setLoading] = useState(false);
+    const [phase, setPhase] = useState<JoinPhase>({ kind: "idle" });
 
-    // Step 1: Invite code
     const [inviteCode, setInviteCode] = useState("");
 
-    // Step 2: Household preview
     const [household, setHousehold] = useState<any>(null);
     const [members, setMembers] = useState<any[]>([]);
 
-    // Step 3: Sign up form
     const [fullName, setFullName] = useState("");
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
@@ -45,7 +53,31 @@ export const JoinHouseholdWizard = ({ open, onOpenChange }: JoinHouseholdWizardP
         setEmail("");
         setPassword("");
         setConfirmPassword("");
+        setPhase({ kind: "idle" });
     };
+
+    useEffect(() => {
+        if (phase.kind !== "settling") return;
+        const { userId, householdId } = phase.expected;
+        const userMatch = user?.id === userId;
+        const householdMatch = activeHousehold?.id === householdId;
+
+        // eslint-disable-next-line no-console
+        console.debug("[JoinWizard] settling check", {
+            userMatch, expectedUser: userId, actualUser: user?.id,
+            householdMatch, expectedHousehold: householdId, actualHousehold: activeHousehold?.id,
+            isUnlocked,
+        });
+
+        if (!userMatch || !householdMatch || !isUnlocked) return;
+
+        toast({
+            title: "Account Created!",
+            description: `You've joined ${household?.name ?? "the household"}.`,
+        });
+        resetWizard();
+        onOpenChange(false);
+    }, [phase, user?.id, activeHousehold?.id, isUnlocked]);
 
     const handleValidateCode = async () => {
         if (!inviteCode || inviteCode.length !== 8) {
@@ -78,6 +110,9 @@ export const JoinHouseholdWizard = ({ open, onOpenChange }: JoinHouseholdWizardP
             household_name: string;
             household_currency: string;
             invited_email: string | null;
+            encrypted_dek: string | null;
+            dek_iv: string | null;
+            dek_salt: string | null;
             members: Array<{
                 role: string;
                 full_name: string | null;
@@ -85,11 +120,24 @@ export const JoinHouseholdWizard = ({ open, onOpenChange }: JoinHouseholdWizardP
             }>;
         };
 
+        if (!preview.encrypted_dek || !preview.dek_iv || !preview.dek_salt) {
+            toast({
+                title: "Invite outdated",
+                description: "This invite was created before encrypted sharing was set up. Ask the inviter to send a new one.",
+                variant: "destructive",
+            });
+            setLoading(false);
+            return;
+        }
+
         setHousehold({
             id: preview.household_id,
             name: preview.household_name,
             currency: preview.household_currency,
             invited_email: preview.invited_email,
+            encrypted_dek: preview.encrypted_dek,
+            dek_iv: preview.dek_iv,
+            dek_salt: preview.dek_salt,
         });
         setMembers(
             preview.members.map((m, idx) => ({
@@ -149,8 +197,9 @@ export const JoinHouseholdWizard = ({ open, onOpenChange }: JoinHouseholdWizardP
         }
 
         setLoading(true);
+        setPhase({ kind: "joining", message: "Creating your account…" });
 
-        const { error } = await signUpAndJoinHousehold(email, password, fullName, inviteCode);
+        const { error, userId, householdId } = await signUpAndJoinHousehold(email, password, fullName, inviteCode);
 
         if (error) {
             const message =
@@ -161,33 +210,89 @@ export const JoinHouseholdWizard = ({ open, onOpenChange }: JoinHouseholdWizardP
                     : error.message === "already_member"
                     ? "You are already a member of this household."
                     : error.message || "Failed to create account";
-
-            toast({
-                title: "Sign Up Failed",
-                description: message,
-                variant: "destructive",
-            });
+            setPhase({ kind: "error", message });
             setLoading(false);
             return;
         }
 
-        toast({
-            title: "Account Created!",
-            description: `You've joined ${household.name}! Please check your email to confirm your account before logging in.`,
-        });
+        if (!userId || !householdId) {
+            setPhase({ kind: "error", message: "Account created but the invite could not be redeemed." });
+            setLoading(false);
+            return;
+        }
 
-        resetWizard();
-        onOpenChange(false);
+        if (!household.encrypted_dek || !household.dek_iv || !household.dek_salt) {
+            setPhase({ kind: "error", message: "Invite is missing the shared encryption key. Ask for a new one." });
+            setLoading(false);
+            return;
+        }
+
+        setPhase({ kind: "joining", message: "Setting up your secure vault…" });
+
+        const vaultOk = await setupVaultFromInvite({
+            userId,
+            householdId,
+            password,
+            inviteCode,
+            wrappedDEK: {
+                encryptedDEK: household.encrypted_dek,
+                dekSalt: household.dek_salt,
+                dekIV: household.dek_iv,
+            },
+        });
+        if (!vaultOk) {
+            setPhase({ kind: "error", message: "Your account was created but encryption setup failed. Contact the household owner." });
+            setLoading(false);
+            return;
+        }
+
+        setPhase({ kind: "joining", message: "Loading your household…" });
+        await refreshHousehold();
+
+        // Hand off to the invariant-watcher effect; it closes the wizard only
+        // once auth, household, and vault have all caught up.
+        setPhase({ kind: "settling", expected: { userId, householdId } });
         setLoading(false);
     };
 
+    const inFlight = phase.kind === "joining" || phase.kind === "settling";
+    const inFlightMessage = phase.kind === "joining"
+        ? phase.message
+        : phase.kind === "settling"
+            ? "Settling you into your household…"
+            : "";
+
     return (
         <Dialog open={open} onOpenChange={(open) => {
+            if (inFlight) return; // Block dismissal mid-flight.
             onOpenChange(open);
             if (!open) resetWizard();
         }}>
-            <DialogContent className="sm:max-w-[500px]">
-                {step === 1 && (
+            <DialogContent
+                className="sm:max-w-[500px]"
+                hideClose={inFlight}
+                onPointerDownOutside={(e) => { if (inFlight) e.preventDefault(); }}
+                onEscapeKeyDown={(e) => { if (inFlight) e.preventDefault(); }}
+            >
+                {inFlight ? (
+                    <div className="flex flex-col items-center justify-center py-10 gap-4">
+                        <Loader2 className="h-8 w-8 animate-spin text-accent" />
+                        <p className="text-sm text-muted-foreground">
+                            {inFlightMessage}
+                        </p>
+                    </div>
+                ) : phase.kind === "error" ? (
+                    <>
+                        <DialogHeader>
+                            <DialogTitle>Something went wrong</DialogTitle>
+                            <DialogDescription>{phase.message}</DialogDescription>
+                        </DialogHeader>
+                        <DialogFooter>
+                            <Button variant="outline" onClick={() => onOpenChange(false)}>Close</Button>
+                            <Button onClick={() => setPhase({ kind: "idle" })}>Try again</Button>
+                        </DialogFooter>
+                    </>
+                ) : step === 1 ? (
                     <>
                         <DialogHeader>
                             <DialogTitle>Join Existing Household</DialogTitle>
@@ -218,9 +323,7 @@ export const JoinHouseholdWizard = ({ open, onOpenChange }: JoinHouseholdWizardP
                             </Button>
                         </DialogFooter>
                     </>
-                )}
-
-                {step === 2 && household && (
+                ) : step === 2 && household ? (
                     <>
                         <DialogHeader>
                             <DialogTitle className="flex items-center gap-2">
@@ -266,9 +369,7 @@ export const JoinHouseholdWizard = ({ open, onOpenChange }: JoinHouseholdWizardP
                             </Button>
                         </DialogFooter>
                     </>
-                )}
-
-                {step === 3 && (
+                ) : step === 3 ? (
                     <>
                         <DialogHeader>
                             <DialogTitle>Create Your Account</DialogTitle>
@@ -327,7 +428,7 @@ export const JoinHouseholdWizard = ({ open, onOpenChange }: JoinHouseholdWizardP
                             </Button>
                         </DialogFooter>
                     </>
-                )}
+                ) : null}
             </DialogContent>
         </Dialog>
     );

--- a/frontend/src/components/JoinHouseholdWizard.tsx
+++ b/frontend/src/components/JoinHouseholdWizard.tsx
@@ -1,17 +1,15 @@
 import { useEffect, useState } from "react";
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
 import { useEncryption } from "@/contexts/EncryptionContext";
 import { useHousehold } from "@/contexts/HouseholdContext";
 import { useToast } from "@/hooks/use-toast";
-import { Check, Users, ArrowRight, ArrowLeft, Loader2 } from "lucide-react";
-import { PLACEHOLDERS } from "@/constants/ui";
 import { passwordSchema } from "@/config/passwordSchema";
+import { JoinStepCode } from "./join/JoinStepCode";
+import { JoinStepPreview, type PreviewMember } from "./join/JoinStepPreview";
+import { JoinStepSignup } from "./join/JoinStepSignup";
+import { JoinInFlightView, JoinErrorView } from "./join/JoinPhaseView";
 
 interface JoinHouseholdWizardProps {
     open: boolean;
@@ -24,6 +22,16 @@ type JoinPhase =
     | { kind: "settling"; expected: { userId: string; householdId: string } }
     | { kind: "error"; message: string };
 
+interface PreviewedHousehold {
+    id: string;
+    name: string;
+    currency: string;
+    invited_email: string | null;
+    encrypted_dek: string;
+    dek_iv: string;
+    dek_salt: string;
+}
+
 export const JoinHouseholdWizard = ({ open, onOpenChange }: JoinHouseholdWizardProps) => {
     const { user, signUpAndJoinHousehold } = useAuth();
     const { setupVaultFromInvite, isUnlocked } = useEncryption();
@@ -35,9 +43,8 @@ export const JoinHouseholdWizard = ({ open, onOpenChange }: JoinHouseholdWizardP
     const [phase, setPhase] = useState<JoinPhase>({ kind: "idle" });
 
     const [inviteCode, setInviteCode] = useState("");
-
-    const [household, setHousehold] = useState<any>(null);
-    const [members, setMembers] = useState<any[]>([]);
+    const [household, setHousehold] = useState<PreviewedHousehold | null>(null);
+    const [members, setMembers] = useState<PreviewMember[]>([]);
 
     const [fullName, setFullName] = useState("");
     const [email, setEmail] = useState("");
@@ -113,11 +120,7 @@ export const JoinHouseholdWizard = ({ open, onOpenChange }: JoinHouseholdWizardP
             encrypted_dek: string | null;
             dek_iv: string | null;
             dek_salt: string | null;
-            members: Array<{
-                role: string;
-                full_name: string | null;
-                avatar_url: string | null;
-            }>;
+            members: Array<{ role: string; full_name: string | null; avatar_url: string | null }>;
         };
 
         if (!preview.encrypted_dek || !preview.dek_iv || !preview.dek_salt) {
@@ -156,6 +159,8 @@ export const JoinHouseholdWizard = ({ open, onOpenChange }: JoinHouseholdWizardP
     };
 
     const handleSignUp = async () => {
+        if (!household) return;
+
         if (!fullName || !email || !password) {
             toast({
                 title: "Missing Information",
@@ -165,7 +170,7 @@ export const JoinHouseholdWizard = ({ open, onOpenChange }: JoinHouseholdWizardP
             return;
         }
 
-        if (household?.invited_email && email.toLowerCase() !== household.invited_email.toLowerCase()) {
+        if (household.invited_email && email.toLowerCase() !== household.invited_email.toLowerCase()) {
             toast({
                 title: "Email Mismatch",
                 description: `This invite is for ${household.invited_email}. Please use the correct email address.`,
@@ -173,9 +178,6 @@ export const JoinHouseholdWizard = ({ open, onOpenChange }: JoinHouseholdWizardP
             });
             return;
         }
-
-        // Invite IS the authorization here — don't double-gate behind the
-        // whitelist that's meant for unsolicited signups.
 
         if (password !== confirmPassword) {
             toast({
@@ -221,12 +223,6 @@ export const JoinHouseholdWizard = ({ open, onOpenChange }: JoinHouseholdWizardP
             return;
         }
 
-        if (!household.encrypted_dek || !household.dek_iv || !household.dek_salt) {
-            setPhase({ kind: "error", message: "Invite is missing the shared encryption key. Ask for a new one." });
-            setLoading(false);
-            return;
-        }
-
         setPhase({ kind: "joining", message: "Setting up your secure vault…" });
 
         const vaultOk = await setupVaultFromInvite({
@@ -249,8 +245,8 @@ export const JoinHouseholdWizard = ({ open, onOpenChange }: JoinHouseholdWizardP
         setPhase({ kind: "joining", message: "Loading your household…" });
         await refreshHousehold();
 
-        // Hand off to the invariant-watcher effect; it closes the wizard only
-        // once auth, household, and vault have all caught up.
+        // Hand off to the invariant-watcher above; it closes only once auth,
+        // household, and vault have all caught up.
         setPhase({ kind: "settling", expected: { userId, householdId } });
         setLoading(false);
     };
@@ -263,10 +259,10 @@ export const JoinHouseholdWizard = ({ open, onOpenChange }: JoinHouseholdWizardP
             : "";
 
     return (
-        <Dialog open={open} onOpenChange={(open) => {
-            if (inFlight) return; // Block dismissal mid-flight.
-            onOpenChange(open);
-            if (!open) resetWizard();
+        <Dialog open={open} onOpenChange={(next) => {
+            if (inFlight) return;
+            onOpenChange(next);
+            if (!next) resetWizard();
         }}>
             <DialogContent
                 className="sm:max-w-[500px]"
@@ -275,159 +271,43 @@ export const JoinHouseholdWizard = ({ open, onOpenChange }: JoinHouseholdWizardP
                 onEscapeKeyDown={(e) => { if (inFlight) e.preventDefault(); }}
             >
                 {inFlight ? (
-                    <div className="flex flex-col items-center justify-center py-10 gap-4">
-                        <Loader2 className="h-8 w-8 animate-spin text-accent" />
-                        <p className="text-sm text-muted-foreground">
-                            {inFlightMessage}
-                        </p>
-                    </div>
+                    <JoinInFlightView message={inFlightMessage} />
                 ) : phase.kind === "error" ? (
-                    <>
-                        <DialogHeader>
-                            <DialogTitle>Something went wrong</DialogTitle>
-                            <DialogDescription>{phase.message}</DialogDescription>
-                        </DialogHeader>
-                        <DialogFooter>
-                            <Button variant="outline" onClick={() => onOpenChange(false)}>Close</Button>
-                            <Button onClick={() => setPhase({ kind: "idle" })}>Try again</Button>
-                        </DialogFooter>
-                    </>
+                    <JoinErrorView
+                        message={phase.message}
+                        onClose={() => onOpenChange(false)}
+                        onRetry={() => setPhase({ kind: "idle" })}
+                    />
                 ) : step === 1 ? (
-                    <>
-                        <DialogHeader>
-                            <DialogTitle>Join Existing Household</DialogTitle>
-                            <DialogDescription>
-                                Enter the 8-character invite code you received
-                            </DialogDescription>
-                        </DialogHeader>
-                        <div className="space-y-4 py-4">
-                            <div className="space-y-2">
-                                <Label htmlFor="invite-code">Invite Code</Label>
-                                <Input
-                                    id="invite-code"
-                                    placeholder="ABCD2345"
-                                    value={inviteCode}
-                                    onChange={(e) => setInviteCode(e.target.value.toUpperCase())}
-                                    maxLength={8}
-                                    className="text-center text-2xl font-mono tracking-widest"
-                                />
-                            </div>
-                        </div>
-                        <DialogFooter>
-                            <Button variant="outline" onClick={() => onOpenChange(false)}>
-                                Cancel
-                            </Button>
-                            <Button onClick={handleValidateCode} disabled={loading || inviteCode.length !== 8}>
-                                {loading ? "Validating..." : "Continue"}
-                                <ArrowRight className="ml-2 h-4 w-4" />
-                            </Button>
-                        </DialogFooter>
-                    </>
+                    <JoinStepCode
+                        inviteCode={inviteCode}
+                        setInviteCode={setInviteCode}
+                        loading={loading}
+                        onCancel={() => onOpenChange(false)}
+                        onContinue={handleValidateCode}
+                    />
                 ) : step === 2 && household ? (
-                    <>
-                        <DialogHeader>
-                            <DialogTitle className="flex items-center gap-2">
-                                <Users className="h-5 w-5" />
-                                {household.name}
-                            </DialogTitle>
-                            <DialogDescription>
-                                You're about to join this household
-                            </DialogDescription>
-                        </DialogHeader>
-                        <div className="space-y-4 py-4">
-                            <div>
-                                <h4 className="text-sm mb-3">Current Members ({members.length})</h4>
-                                <div className="space-y-2">
-                                    {members.map((member) => (
-                                        <div key={member.id} className="flex items-center gap-3 p-2 rounded-lg border">
-                                            <Avatar className="h-8 w-8">
-                                                <AvatarImage src={member.profiles?.avatar_url} />
-                                                <AvatarFallback>
-                                                    {member.profiles?.full_name?.split(" ").map((n: string) => n[0]).join("").toUpperCase() || "?"}
-                                                </AvatarFallback>
-                                            </Avatar>
-                                            <div className="flex-1">
-                                                <p className="font-medium">{member.profiles?.full_name || "Unknown"}</p>
-                                                <p className="text-xs text-muted-foreground capitalize">{member.role}</p>
-                                            </div>
-                                            {member.role === "owner" && (
-                                                <Check className="h-4 w-4 text-success" />
-                                            )}
-                                        </div>
-                                    ))}
-                                </div>
-                            </div>
-                        </div>
-                        <DialogFooter>
-                            <Button variant="outline" onClick={() => setStep(1)}>
-                                <ArrowLeft className="mr-2 h-4 w-4" />
-                                Back
-                            </Button>
-                            <Button onClick={() => setStep(3)}>
-                                Continue to Sign Up
-                                <ArrowRight className="ml-2 h-4 w-4" />
-                            </Button>
-                        </DialogFooter>
-                    </>
-                ) : step === 3 ? (
-                    <>
-                        <DialogHeader>
-                            <DialogTitle>Create Your Account</DialogTitle>
-                            <DialogDescription>
-                                You'll join {household?.name} after creating your account
-                            </DialogDescription>
-                        </DialogHeader>
-                        <div className="space-y-4 py-4">
-                            <div className="space-y-2">
-                                <Label htmlFor="fullName">Full Name</Label>
-                                <Input
-                                    id="fullName"
-                                    placeholder="John Doe"
-                                    value={fullName}
-                                    onChange={(e) => setFullName(e.target.value)}
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <Label htmlFor="email">Email</Label>
-                                <Input
-                                    id="email"
-                                    type="email"
-                                    placeholder={PLACEHOLDERS.EMAIL}
-                                    value={email}
-                                    onChange={(e) => setEmail(e.target.value)}
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <Label htmlFor="password">Password</Label>
-                                <Input
-                                    id="password"
-                                    type="password"
-                                    placeholder="••••••••"
-                                    value={password}
-                                    onChange={(e) => setPassword(e.target.value)}
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <Label htmlFor="confirmPassword">Confirm Password</Label>
-                                <Input
-                                    id="confirmPassword"
-                                    type="password"
-                                    placeholder="••••••••"
-                                    value={confirmPassword}
-                                    onChange={(e) => setConfirmPassword(e.target.value)}
-                                />
-                            </div>
-                        </div>
-                        <DialogFooter>
-                            <Button variant="outline" onClick={() => setStep(2)}>
-                                <ArrowLeft className="mr-2 h-4 w-4" />
-                                Back
-                            </Button>
-                            <Button onClick={handleSignUp} disabled={loading}>
-                                {loading ? "Creating Account..." : "Create Account & Join"}
-                            </Button>
-                        </DialogFooter>
-                    </>
+                    <JoinStepPreview
+                        householdName={household.name}
+                        members={members}
+                        onBack={() => setStep(1)}
+                        onContinue={() => setStep(3)}
+                    />
+                ) : step === 3 && household ? (
+                    <JoinStepSignup
+                        householdName={household.name}
+                        fullName={fullName}
+                        setFullName={setFullName}
+                        email={email}
+                        setEmail={setEmail}
+                        password={password}
+                        setPassword={setPassword}
+                        confirmPassword={confirmPassword}
+                        setConfirmPassword={setConfirmPassword}
+                        loading={loading}
+                        onBack={() => setStep(2)}
+                        onSignUp={handleSignUp}
+                    />
                 ) : null}
             </DialogContent>
         </Dialog>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import { GuidedTour } from "./shared/GuidedTour";
 import { OutageBanner } from "./shared/OutageBanner";
 import { DevTimeTravel } from "./dev/DevTimeTravel";
 import { RecoveryCodeGate } from "./auth/RecoveryCodeGate";
+import { MultiHouseholdExitDialog } from "./auth/MultiHouseholdExitDialog";
 
 interface LayoutProps {
   children: ReactNode;
@@ -42,6 +43,7 @@ const Layout = ({ children }: LayoutProps) => {
       <OutageBanner />
       <DevTimeTravel />
       <RecoveryCodeGate />
+      <MultiHouseholdExitDialog />
     </div>
   );
 };

--- a/frontend/src/components/auth/MultiHouseholdExitDialog.tsx
+++ b/frontend/src/components/auth/MultiHouseholdExitDialog.tsx
@@ -1,0 +1,463 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+    Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Card } from "@/components/ui/card";
+import { RowItem } from "@/components/ui/row-item";
+import { CatIcon } from "@/components/ui/cat-icon";
+import { ServiceIcon } from "@/components/ui/service-icon";
+import { Money } from "@/components/ui/money";
+import { Loader2, ArrowRight, TrendingUp, Home, Repeat, Shield, Sparkles } from "lucide-react";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/contexts/AuthContext";
+import { useEncryption } from "@/contexts/EncryptionContext";
+import { useHousehold } from "@/contexts/HouseholdContext";
+import { toast } from "@/hooks/use-toast";
+import { insuranceTypes } from "@/constants/insuranceTypes";
+import { subscriptionCategories } from "@/constants/subscriptionCategories";
+import { getCategoryById } from "@/constants/expenseCategories";
+import { getIncomeCategoryById } from "@/constants/incomeCategories";
+import { getCurrentFinancialMonth, getFinancialMonthRange } from "@/utils/dateUtils";
+import { format } from "date-fns";
+
+type SectionKey = "income_sources" | "expenses" | "subscriptions" | "insurances";
+
+interface SectionConfig {
+    key: SectionKey;
+    title: string;
+    sectionIcon: any;
+    encryptedCols: string[];
+    primaryLabelCol: string;
+    fallbackLabelCol?: string;
+    amountCol: string;
+    authorCol: "created_by" | "owner_id";
+    subjectCol: "subject_id" | null;
+    coParentCol: "co_parent_id" | null;
+}
+
+const SECTIONS: SectionConfig[] = [
+    {
+        key: "income_sources",
+        title: "Income sources",
+        sectionIcon: TrendingUp,
+        encryptedCols: ["encrypted_name", "encrypted_provider", "encrypted_default_amount"],
+        primaryLabelCol: "encrypted_provider",
+        fallbackLabelCol: "encrypted_name",
+        amountCol: "encrypted_default_amount",
+        authorCol: "owner_id",
+        subjectCol: null,
+        coParentCol: "co_parent_id",
+    },
+    {
+        key: "expenses",
+        title: "Fixed expenses",
+        sectionIcon: Home,
+        encryptedCols: ["encrypted_name", "encrypted_default_amount"],
+        primaryLabelCol: "encrypted_name",
+        amountCol: "encrypted_default_amount",
+        authorCol: "created_by",
+        subjectCol: "subject_id",
+        coParentCol: null,
+    },
+    {
+        key: "subscriptions",
+        title: "Subscriptions",
+        sectionIcon: Repeat,
+        encryptedCols: ["encrypted_name", "encrypted_service", "encrypted_amount"],
+        primaryLabelCol: "encrypted_service",
+        fallbackLabelCol: "encrypted_name",
+        amountCol: "encrypted_amount",
+        authorCol: "created_by",
+        subjectCol: "subject_id",
+        coParentCol: null,
+    },
+    {
+        key: "insurances",
+        title: "Insurances",
+        sectionIcon: Shield,
+        encryptedCols: ["encrypted_name", "encrypted_total_amount", "encrypted_provider"],
+        primaryLabelCol: "encrypted_name",
+        fallbackLabelCol: "encrypted_provider",
+        amountCol: "encrypted_total_amount",
+        authorCol: "created_by",
+        subjectCol: "subject_id",
+        coParentCol: "co_parent_id",
+    },
+];
+
+interface FetchedItem {
+    id: string;
+    raw: Record<string, any>;
+    label: string;
+    amount: number | null;
+    billingCycle: string | null;
+    category: string | null;
+    authoredByMe: boolean;
+    subjectId: string | null;
+    section: SectionKey;
+}
+
+function categoryFor(section: SectionKey, category: string | null) {
+    if (!category) return { icon: Sparkles, hue: undefined as number | undefined };
+    if (section === "income_sources") {
+        const c = getIncomeCategoryById(category);
+        return { icon: c?.icon ?? Sparkles, hue: c?.hue };
+    }
+    if (section === "subscriptions") {
+        const c = subscriptionCategories.find(s => s.value === category);
+        return { icon: c?.icon ?? Sparkles, hue: c?.hue };
+    }
+    if (section === "insurances") {
+        const c = insuranceTypes.find(s => s.value === category);
+        return { icon: c?.icon ?? Sparkles, hue: c?.hue };
+    }
+    const c = getCategoryById(category);
+    return { icon: c?.icon ?? Sparkles, hue: c?.hue };
+}
+
+function billingSuffix(cycle: string | null): string {
+    if (!cycle || cycle === "monthly") return "";
+    if (cycle === "yearly") return "/yr";
+    if (cycle === "semi_annually") return "/6mo";
+    if (cycle === "quarterly") return "/3mo";
+    return `/${cycle}`;
+}
+
+export const MultiHouseholdExitDialog = () => {
+    const { user } = useAuth();
+    const { household: activeHousehold, refresh: refreshHousehold } = useHousehold();
+    const {
+        pendingExitHouseholdId,
+        decryptFromPendingExit,
+        encrypt,
+        clearPendingExitDEK,
+        isUnlocked,
+    } = useEncryption();
+
+    const [loading, setLoading] = useState(true);
+    const [submitting, setSubmitting] = useState(false);
+    const [items, setItems] = useState<FetchedItem[]>([]);
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+    const [householdName, setHouseholdName] = useState<string | null>(null);
+
+    const open = !!pendingExitHouseholdId && isUnlocked;
+
+    useEffect(() => {
+        if (!open || !pendingExitHouseholdId || !user) return;
+        let cancelled = false;
+
+        (async () => {
+            setLoading(true);
+
+            const { data: hh } = await supabase
+                .from("households")
+                .select("name")
+                .eq("id", pendingExitHouseholdId)
+                .single();
+            if (cancelled) return;
+            setHouseholdName(hh?.name ?? null);
+
+            const fetched: FetchedItem[] = [];
+            for (const section of SECTIONS) {
+                const { data, error } = await (supabase as any)
+                    .from(section.key)
+                    .select("*")
+                    .eq("household_id", pendingExitHouseholdId);
+                if (error || !data) continue;
+
+                for (const row of data) {
+                    const primaryCipher = row[section.primaryLabelCol];
+                    const fallbackCipher = section.fallbackLabelCol ? row[section.fallbackLabelCol] : null;
+                    const primary = primaryCipher ? await decryptFromPendingExit(primaryCipher) : null;
+                    const fallback = fallbackCipher ? await decryptFromPendingExit(fallbackCipher) : null;
+                    const category = row.category ?? null;
+                    const label = (primary && primary.trim())
+                        || (fallback && fallback.trim())
+                        || (section.key === "insurances" ? insuranceTypes.find(t => t.value === category)?.label : null)
+                        || "Untitled";
+
+                    const amountCipher = row[section.amountCol];
+                    const amountPlain = amountCipher ? await decryptFromPendingExit(amountCipher) : null;
+                    const amountNum = amountPlain ? parseFloat(amountPlain) : NaN;
+
+                    fetched.push({
+                        id: row.id,
+                        raw: row,
+                        label,
+                        amount: Number.isFinite(amountNum) ? amountNum : null,
+                        billingCycle: row.billing_cycle ?? null,
+                        category,
+                        authoredByMe: row[section.authorCol] === user.id,
+                        subjectId: section.subjectCol ? row[section.subjectCol] ?? null : null,
+                        section: section.key,
+                    });
+                }
+            }
+
+            if (cancelled) return;
+            setItems(fetched);
+            setSelectedIds(new Set(fetched.filter(i => i.authoredByMe).map(i => i.id)));
+            setLoading(false);
+        })();
+
+        return () => { cancelled = true; };
+    }, [open, pendingExitHouseholdId, user?.id, decryptFromPendingExit]);
+
+    const toggleItem = (id: string) => {
+        setSelectedIds(prev => {
+            const next = new Set(prev);
+            if (next.has(id)) next.delete(id); else next.add(id);
+            return next;
+        });
+    };
+
+    const itemsBySection = useMemo(() => {
+        const m = new Map<SectionKey, FetchedItem[]>();
+        for (const s of SECTIONS) m.set(s.key, []);
+        for (const item of items) m.get(item.section)?.push(item);
+        return m;
+    }, [items]);
+
+    const handleConfirm = async () => {
+        if (!user || !activeHousehold?.id || !pendingExitHouseholdId) return;
+        setSubmitting(true);
+
+        try {
+            const subjectIdsToInclude = new Set<string>();
+            for (const item of items) {
+                if (selectedIds.has(item.id) && item.subjectId) {
+                    subjectIdsToInclude.add(item.subjectId);
+                }
+            }
+
+            const subjectIdMap = new Map<string, string>();
+            if (subjectIdsToInclude.size > 0) {
+                const { data: oldSubjects } = await supabase
+                    .from("subjects")
+                    .select("*")
+                    .in("id", Array.from(subjectIdsToInclude));
+                for (const sub of oldSubjects ?? []) {
+                    const { data: inserted } = await supabase
+                        .from("subjects")
+                        .insert({
+                            household_id: activeHousehold.id,
+                            type: sub.type as any,
+                            name: sub.name,
+                            user_id: sub.user_id === user.id ? user.id : null,
+                            sort_order: sub.sort_order ?? 0,
+                        })
+                        .select("id")
+                        .single();
+                    if (inserted) subjectIdMap.set(sub.id, inserted.id);
+                }
+            }
+
+            // Seed monthly_* rows for the current financial month so Overview
+            // shows the brought sources immediately (Income/Expenses pages would
+            // otherwise have to be visited first to trigger their carry-forward).
+            const financialMonthStart = (activeHousehold as any).financial_month_start || 25;
+            const month = getCurrentFinancialMonth(financialMonthStart);
+            const { start, end } = getFinancialMonthRange(month, financialMonthStart);
+            const monthStartStr = format(start, "yyyy-MM-dd");
+            const monthEndStr = format(end, "yyyy-MM-dd");
+
+            for (const section of SECTIONS) {
+                const picked = items.filter(i => i.section === section.key && selectedIds.has(i.id));
+                for (const item of picked) {
+                    const newRow: Record<string, any> = { ...item.raw };
+                    delete newRow.id;
+                    delete newRow.created_at;
+                    delete newRow.updated_at;
+                    newRow.household_id = activeHousehold.id;
+                    if (section.authorCol === "owner_id") newRow.owner_id = user.id;
+                    else newRow.created_by = user.id;
+
+                    let amountPlain: string | null = null;
+                    for (const col of section.encryptedCols) {
+                        const cipher = item.raw[col];
+                        if (!cipher) { newRow[col] = null; continue; }
+                        const plain = await decryptFromPendingExit(cipher);
+                        if (plain == null) { newRow[col] = null; continue; }
+                        if (col === section.amountCol) amountPlain = plain;
+                        newRow[col] = await encrypt(plain);
+                    }
+
+                    if (section.subjectCol) {
+                        const oldSubjId = item.raw[section.subjectCol];
+                        newRow[section.subjectCol] = oldSubjId ? subjectIdMap.get(oldSubjId) ?? null : null;
+                    }
+                    if (section.coParentCol) {
+                        newRow[section.coParentCol] = null;
+                    }
+
+                    const { data: insertedSource, error: insertError } = await (supabase as any)
+                        .from(section.key)
+                        .insert(newRow)
+                        .select("id")
+                        .single();
+                    if (insertError || !insertedSource) {
+                        throw new Error(`Failed to bring ${section.title}: ${insertError?.message ?? "no row returned"}`);
+                    }
+
+                    if (section.key === "income_sources" && amountPlain) {
+                        const encryptedBudget = await encrypt(amountPlain);
+                        await (supabase as any).from("monthly_incomes").insert({
+                            income_source_id: insertedSource.id,
+                            household_id: activeHousehold.id,
+                            month,
+                            month_start: monthStartStr,
+                            month_end: monthEndStr,
+                            encrypted_budget_amount: encryptedBudget,
+                            created_by: user.id,
+                        });
+                    } else if (section.key === "expenses" && amountPlain) {
+                        const encryptedBudget = await encrypt(amountPlain);
+                        await (supabase as any).from("monthly_expenses").insert({
+                            expense_id: insertedSource.id,
+                            household_id: activeHousehold.id,
+                            month,
+                            month_start: monthStartStr,
+                            month_end: monthEndStr,
+                            encrypted_budget_amount: encryptedBudget,
+                            created_by: user.id,
+                        });
+                    }
+                }
+            }
+
+            const { error: exitError } = await (supabase as any).rpc("confirm_member_exit");
+            if (exitError) throw new Error(exitError.message || "Could not finalize exit");
+
+            clearPendingExitDEK();
+            await refreshHousehold();
+
+            toast({
+                title: "All done",
+                description: selectedIds.size === 0
+                    ? "You're set up in your household."
+                    : `Brought ${selectedIds.size} item${selectedIds.size === 1 ? "" : "s"} into your household.`,
+            });
+
+            // Reload so every page-level fetch (Overview, Income, Expenses) re-runs
+            // against the freshly seeded household state without depending on each
+            // page being visited to refresh itself.
+            setTimeout(() => window.location.reload(), 800);
+        } catch (err: any) {
+            console.error("Exit dialog failed:", err);
+            toast({
+                title: "Couldn't finish",
+                description: err?.message ?? "Try again.",
+                variant: "destructive",
+            });
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={() => { /* not dismissable */ }}>
+            <DialogContent
+                className="sm:max-w-2xl max-h-[90vh] overflow-y-auto"
+                hideClose
+                onPointerDownOutside={(e) => e.preventDefault()}
+                onEscapeKeyDown={(e) => e.preventDefault()}
+            >
+                <DialogHeader>
+                    <DialogTitle>
+                        Bring items from {householdName ?? "your previous household"}
+                    </DialogTitle>
+                    <DialogDescription>
+                        You've been removed from (or left) this household. Pick what to duplicate
+                        into your household. Items you originally added are pre-checked.
+                    </DialogDescription>
+                </DialogHeader>
+
+                {loading ? (
+                    <div className="py-10 flex justify-center">
+                        <Loader2 className="animate-spin h-6 w-6 text-muted-foreground" />
+                    </div>
+                ) : items.length === 0 ? (
+                    <p className="text-sm text-muted-foreground py-6 text-center">
+                        Nothing to bring across. Click finish to continue.
+                    </p>
+                ) : (
+                    <div className="space-y-5 py-2">
+                        {SECTIONS.map(section => {
+                            const sectionItems = itemsBySection.get(section.key) ?? [];
+                            if (sectionItems.length === 0) return null;
+                            const SectionIcon = section.sectionIcon;
+                            return (
+                                <div key={section.key} className="space-y-2">
+                                    <h4 className="text-sm font-medium flex items-center gap-2">
+                                        <SectionIcon className="h-4 w-4 text-muted-foreground" />
+                                        {section.title}
+                                    </h4>
+                                    <Card variant="flush">
+                                        {sectionItems.map((item, idx) => {
+                                            const { icon, hue } = categoryFor(section.key, item.category);
+                                            const isLast = idx === sectionItems.length - 1;
+                                            const checked = selectedIds.has(item.id);
+                                            return (
+                                                <RowItem
+                                                    key={item.id}
+                                                    last={isLast}
+                                                    onClick={() => toggleItem(item.id)}
+                                                >
+                                                    <Checkbox
+                                                        checked={checked}
+                                                        onCheckedChange={() => toggleItem(item.id)}
+                                                        onClick={(e) => e.stopPropagation()}
+                                                    />
+                                                    {section.key === "subscriptions" ? (
+                                                        <ServiceIcon
+                                                            serviceName={item.label}
+                                                            fallbackIcon={icon}
+                                                            fallbackHue={hue}
+                                                            size={32}
+                                                        />
+                                                    ) : (
+                                                        <CatIcon icon={icon} hue={hue} size={32} />
+                                                    )}
+                                                    <div className="flex-1 min-w-0">
+                                                        <div className="flex items-center gap-2">
+                                                            <span className="font-medium text-sm sm:text-base truncate">{item.label}</span>
+                                                            {item.authoredByMe && (
+                                                                <span className="text-[10px] uppercase tracking-wide text-muted-foreground">by you</span>
+                                                            )}
+                                                        </div>
+                                                    </div>
+                                                    {item.amount != null && (
+                                                        <span className="flex items-baseline gap-1 shrink-0">
+                                                            <Money v={item.amount} currency="SEK" size="base" weight={500} />
+                                                            {billingSuffix(item.billingCycle) && (
+                                                                <span className="text-xs text-muted-foreground">{billingSuffix(item.billingCycle)}</span>
+                                                            )}
+                                                        </span>
+                                                    )}
+                                                </RowItem>
+                                            );
+                                        })}
+                                    </Card>
+                                </div>
+                            );
+                        })}
+                    </div>
+                )}
+
+                <DialogFooter>
+                    <Button onClick={handleConfirm} disabled={submitting || loading}>
+                        {submitting ? (
+                            <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Bringing…</>
+                        ) : items.length === 0 ? (
+                            <>Finish <ArrowRight className="h-4 w-4 ml-2" /></>
+                        ) : (
+                            <>Bring {selectedIds.size} item{selectedIds.size === 1 ? "" : "s"} <ArrowRight className="h-4 w-4 ml-2" /></>
+                        )}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};

--- a/frontend/src/components/dashboard/HouseholdSetupWizard.tsx
+++ b/frontend/src/components/dashboard/HouseholdSetupWizard.tsx
@@ -274,7 +274,7 @@ export const HouseholdSetupWizard = ({
                                     key={it.id}
                                     className="flex items-center justify-between p-3 rounded-lg border border-line"
                                 >
-                                    <span className="font-medium truncate">{it.name}</span>
+                                    <span className="font-medium truncate">{itemLabel(step.key as Exclude<StepKey, "features">, it)}</span>
                                     <span className="text-sm text-muted-foreground tabular-nums">
                                         {summariseAmount(step.key as Exclude<StepKey, "features">, it)}
                                     </span>
@@ -342,6 +342,12 @@ export const HouseholdSetupWizard = ({
         </Dialog>
     );
 };
+
+function itemLabel(stepKey: Exclude<StepKey, "features">, item: any): string {
+    if (stepKey === "income") return item.provider || item.name || "Untitled";
+    if (stepKey === "subscription") return item.service || item.name || "Untitled";
+    return item.name || "Untitled";
+}
 
 function summariseAmount(stepKey: Exclude<StepKey, "features">, item: any): string {
     const v = Number(item.default_amount ?? item.amount ?? item.total_amount ?? 0);

--- a/frontend/src/components/expenses/InsuranceFormDialog.tsx
+++ b/frontend/src/components/expenses/InsuranceFormDialog.tsx
@@ -40,11 +40,9 @@ export const InsuranceFormDialog = ({
                 householdId={householdId}
                 editingId={mode === "edit" ? initialValues?.id : undefined}
                 initialValues={initialValues}
-                onSuccess={() => {
-                    onSuccess?.();
-                    if (mode === "edit") onOpenChange(false);
-                }}
+                onSuccess={() => onSuccess?.()}
                 onCancel={() => onOpenChange(false)}
+                onClose={() => onOpenChange(false)}
                 onDelete={mode === "edit" ? () => {
                     onSuccess?.();
                     onOpenChange(false);

--- a/frontend/src/components/expenses/SubscriptionFormDialog.tsx
+++ b/frontend/src/components/expenses/SubscriptionFormDialog.tsx
@@ -35,11 +35,9 @@ export const SubscriptionFormDialog = ({
                 householdId={householdId}
                 editingId={mode === "edit" ? initialValues?.id : undefined}
                 initialValues={initialValues}
-                onSuccess={() => {
-                    onSuccess?.();
-                    if (mode === "edit") onOpenChange(false);
-                }}
+                onSuccess={() => onSuccess?.()}
                 onCancel={() => onOpenChange(false)}
+                onClose={() => onOpenChange(false)}
                 onDelete={mode === "edit" ? () => {
                     onSuccess?.();
                     onOpenChange(false);

--- a/frontend/src/components/expenses/forms/InsuranceForm.tsx
+++ b/frontend/src/components/expenses/forms/InsuranceForm.tsx
@@ -42,6 +42,7 @@ interface InsuranceFormProps {
     householdId: string;
     onSuccess: () => void;
     onCancel: () => void;
+    onClose?: () => void;
     editingId?: string;
     initialValues?: InitialValues;
     onDelete?: () => void;
@@ -65,7 +66,7 @@ const blank = (): InitialValues => ({
 });
 
 export const InsuranceForm = ({
-    householdId, onSuccess, onCancel,
+    householdId, onSuccess, onCancel, onClose,
     editingId, initialValues, onDelete, showCreateAnother = true,
 }: InsuranceFormProps) => {
     const { user } = useAuth();
@@ -138,6 +139,7 @@ export const InsuranceForm = ({
             if (error) throw error;
         } : undefined,
         onSaved: onSuccess,
+        onClose,
         onDeleted: onDelete,
         resetForm: () => { const b = blank(); setPristine(b); setFormData(b); },
         formValues: formData,
@@ -273,7 +275,7 @@ export const InsuranceForm = ({
                 />
             </FormField>
 
-            <FormField label="Notes">
+            <FormField label="Notes" optional>
                 <Textarea
                     rows={2}
                     value={formData.notes ?? ""}

--- a/frontend/src/components/expenses/forms/SubscriptionForm.tsx
+++ b/frontend/src/components/expenses/forms/SubscriptionForm.tsx
@@ -45,6 +45,7 @@ interface SubscriptionFormProps {
     householdId: string;
     onSuccess: () => void;
     onCancel: () => void;
+    onClose?: () => void;
     /** Pass to enable edit mode. */
     editingId?: string;
     initialValues?: InitialValues;
@@ -65,7 +66,7 @@ const blank = (): InitialValues => ({
 });
 
 export const SubscriptionForm = ({
-    householdId, onSuccess, onCancel,
+    householdId, onSuccess, onCancel, onClose,
     editingId, initialValues, onDelete, showCreateAnother = true,
 }: SubscriptionFormProps) => {
     const { user } = useAuth();
@@ -119,6 +120,7 @@ export const SubscriptionForm = ({
             if (error) throw error;
         } : undefined,
         onSaved: onSuccess,
+        onClose,
         onDeleted: onDelete,
         resetForm: () => { const b = blank(); setPristine(b); setFormData(b); },
         formValues: formData,
@@ -246,7 +248,7 @@ export const SubscriptionForm = ({
                 />
             </FormField>
 
-            <FormField label="Notes">
+            <FormField label="Notes" optional>
                 <Textarea
                     rows={2}
                     value={formData.notes ?? ""}

--- a/frontend/src/components/income/IncomeFormDialog.tsx
+++ b/frontend/src/components/income/IncomeFormDialog.tsx
@@ -10,6 +10,7 @@ import {
     Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from "@/components/ui/select";
 import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/contexts/AuthContext";
 import {
     useEncryptedFields,
     incomeSourceFields,
@@ -79,7 +80,9 @@ export const IncomeFormDialog = ({
     open, onOpenChange, mode, householdId, members, coParents = [],
     financialMonthStart, initialValues, onSuccess,
 }: IncomeFormDialogProps) => {
-    const defaultOwnerId = initialValues?.owner_id || members[0]?.user_id || "";
+    const { user } = useAuth();
+    // Default to the current user, not whoever happens to be members[0].
+    const defaultOwnerId = initialValues?.owner_id || user?.id || members[0]?.user_id || "";
     const [pristine, setPristine] = useState<InitialValues>(() => ({
         ...blankForm(defaultOwnerId),
         ...initialValues,

--- a/frontend/src/components/join/JoinPhaseView.tsx
+++ b/frontend/src/components/join/JoinPhaseView.tsx
@@ -1,0 +1,29 @@
+import { DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
+
+export const JoinInFlightView = ({ message }: { message: string }) => (
+    <div className="flex flex-col items-center justify-center py-10 gap-4">
+        <Loader2 className="h-8 w-8 animate-spin text-accent" />
+        <p className="text-sm text-muted-foreground">{message}</p>
+    </div>
+);
+
+interface JoinErrorViewProps {
+    message: string;
+    onClose: () => void;
+    onRetry: () => void;
+}
+
+export const JoinErrorView = ({ message, onClose, onRetry }: JoinErrorViewProps) => (
+    <>
+        <DialogHeader>
+            <DialogTitle>Something went wrong</DialogTitle>
+            <DialogDescription>{message}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+            <Button variant="outline" onClick={onClose}>Close</Button>
+            <Button onClick={onRetry}>Try again</Button>
+        </DialogFooter>
+    </>
+);

--- a/frontend/src/components/join/JoinStepCode.tsx
+++ b/frontend/src/components/join/JoinStepCode.tsx
@@ -1,0 +1,46 @@
+import { DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ArrowRight } from "lucide-react";
+
+interface JoinStepCodeProps {
+    inviteCode: string;
+    setInviteCode: (v: string) => void;
+    loading: boolean;
+    onCancel: () => void;
+    onContinue: () => void;
+}
+
+export const JoinStepCode = ({ inviteCode, setInviteCode, loading, onCancel, onContinue }: JoinStepCodeProps) => (
+    <>
+        <DialogHeader>
+            <DialogTitle>Join Existing Household</DialogTitle>
+            <DialogDescription>
+                Enter the 8-character invite code you received
+            </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-4">
+            <div className="space-y-2">
+                <Label htmlFor="invite-code">Invite Code</Label>
+                <Input
+                    id="invite-code"
+                    placeholder="ABCD2345"
+                    value={inviteCode}
+                    onChange={(e) => setInviteCode(e.target.value.toUpperCase())}
+                    maxLength={8}
+                    className="text-center text-2xl font-mono tracking-widest"
+                />
+            </div>
+        </div>
+        <DialogFooter>
+            <Button variant="outline" onClick={onCancel}>
+                Cancel
+            </Button>
+            <Button onClick={onContinue} disabled={loading || inviteCode.length !== 8}>
+                {loading ? "Validating..." : "Continue"}
+                <ArrowRight className="ml-2 h-4 w-4" />
+            </Button>
+        </DialogFooter>
+    </>
+);

--- a/frontend/src/components/join/JoinStepPreview.tsx
+++ b/frontend/src/components/join/JoinStepPreview.tsx
@@ -1,0 +1,65 @@
+import { DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Check, Users, ArrowRight, ArrowLeft } from "lucide-react";
+
+export interface PreviewMember {
+    id: string;
+    role: string;
+    profiles?: { full_name?: string | null; avatar_url?: string | null };
+}
+
+interface JoinStepPreviewProps {
+    householdName: string;
+    members: PreviewMember[];
+    onBack: () => void;
+    onContinue: () => void;
+}
+
+export const JoinStepPreview = ({ householdName, members, onBack, onContinue }: JoinStepPreviewProps) => (
+    <>
+        <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+                <Users className="h-5 w-5" />
+                {householdName}
+            </DialogTitle>
+            <DialogDescription>
+                You're about to join this household
+            </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-4">
+            <div>
+                <h4 className="text-sm mb-3">Current Members ({members.length})</h4>
+                <div className="space-y-2">
+                    {members.map((member) => (
+                        <div key={member.id} className="flex items-center gap-3 p-2 rounded-lg border">
+                            <Avatar className="h-8 w-8">
+                                <AvatarImage src={member.profiles?.avatar_url ?? undefined} />
+                                <AvatarFallback>
+                                    {member.profiles?.full_name?.split(" ").map((n: string) => n[0]).join("").toUpperCase() || "?"}
+                                </AvatarFallback>
+                            </Avatar>
+                            <div className="flex-1">
+                                <p className="font-medium">{member.profiles?.full_name || "Unknown"}</p>
+                                <p className="text-xs text-muted-foreground capitalize">{member.role}</p>
+                            </div>
+                            {member.role === "owner" && (
+                                <Check className="h-4 w-4 text-success" />
+                            )}
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </div>
+        <DialogFooter>
+            <Button variant="outline" onClick={onBack}>
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Back
+            </Button>
+            <Button onClick={onContinue}>
+                Continue to Sign Up
+                <ArrowRight className="ml-2 h-4 w-4" />
+            </Button>
+        </DialogFooter>
+    </>
+);

--- a/frontend/src/components/join/JoinStepSignup.tsx
+++ b/frontend/src/components/join/JoinStepSignup.tsx
@@ -1,0 +1,86 @@
+import { DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ArrowLeft } from "lucide-react";
+import { PLACEHOLDERS } from "@/constants/ui";
+
+interface JoinStepSignupProps {
+    householdName: string;
+    fullName: string;
+    setFullName: (v: string) => void;
+    email: string;
+    setEmail: (v: string) => void;
+    password: string;
+    setPassword: (v: string) => void;
+    confirmPassword: string;
+    setConfirmPassword: (v: string) => void;
+    loading: boolean;
+    onBack: () => void;
+    onSignUp: () => void;
+}
+
+export const JoinStepSignup = ({
+    householdName, fullName, setFullName, email, setEmail,
+    password, setPassword, confirmPassword, setConfirmPassword,
+    loading, onBack, onSignUp,
+}: JoinStepSignupProps) => (
+    <>
+        <DialogHeader>
+            <DialogTitle>Create Your Account</DialogTitle>
+            <DialogDescription>
+                You'll join {householdName} after creating your account
+            </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-4">
+            <div className="space-y-2">
+                <Label htmlFor="fullName">Full Name</Label>
+                <Input
+                    id="fullName"
+                    placeholder="John Doe"
+                    value={fullName}
+                    onChange={(e) => setFullName(e.target.value)}
+                />
+            </div>
+            <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                    id="email"
+                    type="email"
+                    placeholder={PLACEHOLDERS.EMAIL}
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                />
+            </div>
+            <div className="space-y-2">
+                <Label htmlFor="password">Password</Label>
+                <Input
+                    id="password"
+                    type="password"
+                    placeholder="••••••••"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                />
+            </div>
+            <div className="space-y-2">
+                <Label htmlFor="confirmPassword">Confirm Password</Label>
+                <Input
+                    id="confirmPassword"
+                    type="password"
+                    placeholder="••••••••"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                />
+            </div>
+        </div>
+        <DialogFooter>
+            <Button variant="outline" onClick={onBack}>
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Back
+            </Button>
+            <Button onClick={onSignUp} disabled={loading}>
+                {loading ? "Creating Account..." : "Create Account & Join"}
+            </Button>
+        </DialogFooter>
+    </>
+);

--- a/frontend/src/components/settings/HouseholdMembersCard.tsx
+++ b/frontend/src/components/settings/HouseholdMembersCard.tsx
@@ -1,12 +1,12 @@
-import { useEncryptedFields, subscriptionFields, insuranceFields } from "@/hooks/useEncryptedFields";
 import { isDemoMode } from "@/utils/demoMode";
+import { useEncryption } from "@/contexts/EncryptionContext";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
-import { Users, UserMinus, Crown, Copy, Check, Trash2 } from "lucide-react";
+import { Users, UserMinus, Crown, Copy, Check, Trash2, LogOut } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/contexts/AuthContext";
@@ -44,6 +44,7 @@ interface HouseholdMembersCardProps {
 export const HouseholdMembersCard = ({ members, householdId, invites, onUpdate }: HouseholdMembersCardProps) => {
   const { toast } = useToast();
   const { user } = useAuth();
+  const { wrapDEKForInvite, isUnlocked } = useEncryption();
   const currentMember = members.find(m => m.user_id === user?.id);
   const isOwner = currentMember?.role === "owner";
   const [isGenerating, setIsGenerating] = useState(false);
@@ -77,10 +78,30 @@ export const HouseholdMembersCard = ({ members, householdId, invites, onUpdate }
       return;
     }
 
+    if (!isUnlocked) {
+      toast({
+        title: "Vault Locked",
+        description: "Unlock your vault before inviting members so the encryption key can be shared.",
+        variant: "destructive",
+      });
+      return;
+    }
+
     setIsGenerating(true);
     const inviteCode = generateInviteCode();
     const expiresAt = new Date();
     expiresAt.setHours(expiresAt.getHours() + 24);
+
+    const wrapped = await wrapDEKForInvite(inviteCode);
+    if (!wrapped) {
+      setIsGenerating(false);
+      toast({
+        title: "Error",
+        description: "Could not prepare encryption key for the invite. Try again.",
+        variant: "destructive",
+      });
+      return;
+    }
 
     const { error } = await supabase
       .from("household_invites")
@@ -91,6 +112,9 @@ export const HouseholdMembersCard = ({ members, householdId, invites, onUpdate }
         created_by: user.id,
         expires_at: expiresAt.toISOString(),
         status: "pending",
+        encrypted_dek: wrapped.encryptedDEK,
+        dek_iv: wrapped.iv,
+        dek_salt: wrapped.salt,
       });
 
     setIsGenerating(false);
@@ -124,24 +148,37 @@ export const HouseholdMembersCard = ({ members, householdId, invites, onUpdate }
   };
 
   const handleRemoveMember = async (memberId: string) => {
-    // Simply delete the member role (their owner role remains, they return to it automatically)
-    const { error: deleteError } = await supabase
-      .from("household_members")
-      .delete()
-      .eq("id", memberId);
+    const target = members.find(m => m.id === memberId);
+    const isSelf = target?.user_id === user?.id;
 
-    if (deleteError) {
+    const { error } = await (supabase as any).rpc("request_member_exit", {
+      member_id_in: memberId,
+    });
+
+    if (error) {
       toast({
         title: "Error",
-        description: "Failed to remove member",
+        description: error.message === "owner_must_transfer_first"
+          ? "The owner can't be removed. Transfer ownership first."
+          : "Failed to remove member",
         variant: "destructive",
       });
       return;
     }
 
+    if (isSelf) {
+      // Reload so unlockWithPassword sees the pending_exit_at and surfaces the dialog.
+      setTimeout(() => window.location.reload(), 1500);
+      toast({
+        title: "Leaving household…",
+        description: "Reloading to set up your own household.",
+      });
+      return;
+    }
+
     toast({
-      title: "Success",
-      description: "Member removed and returned to their household",
+      title: "Removed",
+      description: "They'll see a one-time dialog next time they log in to take items with them.",
     });
     onUpdate();
   };
@@ -206,8 +243,19 @@ export const HouseholdMembersCard = ({ members, householdId, invites, onUpdate }
                   variant="ghost"
                   size="icon"
                   onClick={() => handleRemoveMember(member.id)}
+                  title="Remove member"
                 >
                   <UserMinus className="h-4 w-4" />
+                </Button>
+              )}
+              {!isOwner && member.user_id === user?.id && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleRemoveMember(member.id)}
+                  title="Leave household"
+                >
+                  <LogOut className="h-4 w-4" />
                 </Button>
               )}
             </div>

--- a/frontend/src/components/shared/SubjectPicker.tsx
+++ b/frontend/src/components/shared/SubjectPicker.tsx
@@ -59,29 +59,48 @@ export const SubjectPicker = ({
                 .eq("household_id", householdId)
                 .eq("type", "member");
 
+            const allMemberSubjects = (existing ?? []) as Array<{ id: string; name: string; user_id: string | null }>;
             const existingByUser = new Map<string, { id: string; name: string }>();
-            for (const s of (existing ?? []) as Array<{ id: string; name: string; user_id: string | null }>) {
-                if (s.user_id) existingByUser.set(s.user_id, { id: s.id, name: s.name });
+            const orphansByName = new Map<string, { id: string; name: string }>();
+            for (const s of allMemberSubjects) {
+                if (s.user_id) {
+                    existingByUser.set(s.user_id, { id: s.id, name: s.name });
+                } else {
+                    orphansByName.set(s.name.trim().toLowerCase(), { id: s.id, name: s.name });
+                }
             }
 
             const toInsert: Array<{ household_id: string; user_id: string; name: string; type: "member"; sort_order: number }> = [];
+            const claims: Array<{ id: string; user_id: string; name: string }> = [];
             const renames: Array<{ id: string; name: string }> = [];
 
             for (const m of members as Array<{ user_id: string; profiles: any }>) {
                 const p = Array.isArray(m.profiles) ? m.profiles[0] : m.profiles;
-                const name = p?.full_name || p?.email;
+                const name = (p?.full_name || p?.email || "").trim();
                 if (!name) continue;
                 const current = existingByUser.get(m.user_id);
-                if (!current) {
+                if (current) {
+                    if (current.name !== name) renames.push({ id: current.id, name });
+                    continue;
+                }
+                // No row for this user yet — claim a name-matching orphan if one exists,
+                // otherwise insert a fresh row.
+                const orphan = orphansByName.get(name.toLowerCase());
+                if (orphan) {
+                    claims.push({ id: orphan.id, user_id: m.user_id, name });
+                    orphansByName.delete(name.toLowerCase());
+                } else {
                     toInsert.push({ household_id: householdId, user_id: m.user_id, name, type: "member", sort_order: 0 });
-                } else if (current.name !== name) {
-                    renames.push({ id: current.id, name });
                 }
             }
 
             let changed = false;
             if (toInsert.length > 0) {
                 await supabase.from("subjects").insert(toInsert);
+                changed = true;
+            }
+            for (const c of claims) {
+                await supabase.from("subjects").update({ user_id: c.user_id, name: c.name }).eq("id", c.id);
                 changed = true;
             }
             for (const r of renames) {

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -35,10 +35,16 @@ const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
+interface DialogContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
+  /** Hide the top-right close button (use during multi-step flows that mustn't be dismissed). */
+  hideClose?: boolean;
+}
+
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  DialogContentProps
+>(({ className, children, hideClose, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -69,10 +75,12 @@ const DialogContent = React.forwardRef<
         <div className="w-9 h-1 rounded-full bg-line" />
       </div>
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 w-8 h-8 rounded-full bg-surface-2 hover:bg-surface-2/70 flex items-center justify-center text-ink-2 transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:pointer-events-none">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
+      {!hideClose && (
+        <DialogPrimitive.Close className="absolute right-4 top-4 w-8 h-8 rounded-full bg-surface-2 hover:bg-surface-2/70 flex items-center justify-center text-ink-2 transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:pointer-events-none">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      )}
     </DialogPrimitive.Content>
   </DialogPortal>
 ));

--- a/frontend/src/components/ui/money-input.tsx
+++ b/frontend/src/components/ui/money-input.tsx
@@ -62,7 +62,8 @@ export const MoneyInput = React.forwardRef<HTMLInputElement, MoneyInputProps>(
         },
         ref,
     ) => {
-        const display = value === "" || value == null
+        // Treat 0 as empty so clearing the field doesn't repopulate it.
+        const display = value === "" || value == null || value === 0
             ? ""
             : (typeof value === "number" ? Math.round(value).toString() : value.toString());
 

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -67,7 +67,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity group-hover:opacity-100 group-[.destructive]:text-destructive-foreground/80 hover:text-foreground group-[.destructive]:hover:text-destructive-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-[.destructive]:focus:ring-destructive group-[.destructive]:focus:ring-offset-destructive",
+      "absolute right-2 top-2 rounded-md p-1 text-foreground/70 opacity-80 hover:opacity-100 transition-opacity group-[.destructive]:text-destructive-foreground/80 hover:text-foreground group-[.destructive]:hover:text-destructive-foreground focus:outline-none focus:ring-2 group-[.destructive]:focus:ring-destructive group-[.destructive]:focus:ring-offset-destructive",
       className,
     )}
     toast-close=""

--- a/frontend/src/constants/insuranceTypes.ts
+++ b/frontend/src/constants/insuranceTypes.ts
@@ -2,14 +2,14 @@ import { Home, Car, Heart, User, PawPrint, Plane, Scale, Baby, MoreHorizontal } 
 import { CategoryConfig } from "@/utils/categoryHelpers";
 
 export const insuranceTypes: CategoryConfig[] = [
-    { value: "home", label: "Home Insurance", icon: Home, hue: 50 },
-    { value: "car", label: "Car Insurance", icon: Car, hue: 200 },
-    { value: "health", label: "Health Insurance", icon: Heart, hue: 150 },
-    { value: "child", label: "Child Insurance", icon: Baby, hue: 340 },
-    { value: "life", label: "Life Insurance", icon: User, hue: 100 },
-    { value: "pet", label: "Pet Insurance", icon: PawPrint, hue: 20 },
-    { value: "travel", label: "Travel Insurance", icon: Plane, hue: 200 },
-    { value: "liability", label: "Liability Insurance", icon: Scale, hue: 320 },
+    { value: "home", label: "Home", icon: Home, hue: 50 },
+    { value: "car", label: "Car", icon: Car, hue: 200 },
+    { value: "health", label: "Health", icon: Heart, hue: 150 },
+    { value: "child", label: "Child", icon: Baby, hue: 340 },
+    { value: "life", label: "Life", icon: User, hue: 100 },
+    { value: "pet", label: "Pet", icon: PawPrint, hue: 20 },
+    { value: "travel", label: "Travel", icon: Plane, hue: 200 },
+    { value: "liability", label: "Liability", icon: Scale, hue: 320 },
     { value: "other", label: "Other", icon: MoreHorizontal },
 ];
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -8,7 +8,12 @@ interface AuthContextType {
   loading: boolean;
   signIn: (email: string, password: string) => Promise<{ error: any; data: { user: User | null } | null }>;
   signUp: (email: string, password: string, fullName?: string) => Promise<{ error: any; data: { user: User | null } | null }>;
-  signUpAndJoinHousehold: (email: string, password: string, fullName: string, inviteCode: string) => Promise<{ error: any }>;
+  signUpAndJoinHousehold: (
+    email: string,
+    password: string,
+    fullName: string,
+    inviteCode: string,
+  ) => Promise<{ error: any; userId?: string; householdId?: string }>;
   signOut: () => Promise<void>;
 }
 
@@ -82,7 +87,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       return { error: signUpError };
     }
 
-    const { error: redeemError } = await supabase.rpc("redeem_invite", {
+    const { data: redeemData, error: redeemError } = await supabase.rpc("redeem_invite", {
       invite_code_in: inviteCode.toUpperCase(),
     });
 
@@ -90,29 +95,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       return { error: redeemError };
     }
 
-    // The signup trigger may have provisioned a default household — drop it
-    // so the user lands in the invited one only.
-    const { data: ownedHouseholds } = await supabase
-      .from("households")
-      .select("id")
-      .eq("owner_id", authData.user.id);
-
-    if (ownedHouseholds && ownedHouseholds.length > 0) {
-      for (const household of ownedHouseholds) {
-        await supabase
-          .from("household_members")
-          .delete()
-          .eq("household_id", household.id)
-          .eq("user_id", authData.user.id);
-
-        await supabase
-          .from("households")
-          .delete()
-          .eq("id", household.id);
-      }
-    }
-
-    return { error: null };
+    const householdId = (redeemData as { household_id?: string } | null)?.household_id;
+    return { error: null, userId: authData.user.id, householdId };
   };
 
   const signOut = async () => {

--- a/frontend/src/contexts/EncryptionContext.tsx
+++ b/frontend/src/contexts/EncryptionContext.tsx
@@ -7,54 +7,38 @@ import {
     reEncryptDEK,
     generateRecoveryCode,
     wrapDEKWithRecoveryCode,
+    wrapDEKWithInviteCode,
+    unwrapDEKWithInviteCode,
+    rewrapDEKWithPassword,
 } from '@/services/encryption';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from '@/hooks/use-toast';
 
 interface EncryptionContextValue {
-    /** Whether the vault is unlocked (DEK is available) */
     isUnlocked: boolean;
-
-    /** Whether encryption is being initialized */
     isLoading: boolean;
-
-    /** Encrypt a string value. Returns null if vault is locked. */
     encrypt: (plaintext: string) => Promise<string | null>;
-
-    /** Decrypt a ciphertext. Returns null if vault is locked or decryption fails. */
     decrypt: (ciphertext: string) => Promise<string | null>;
 
-    /** 
-     * Initialize encryption for a new user (during registration).
-     * Generates DEK, encrypts with password, stores in profile.
-     */
-    initializeEncryption: (password: string, userId: string) => Promise<boolean>;
-
-    /**
-     * Unlock the vault using password (during login).
-     * Fetches encrypted DEK from profile, decrypts it.
-     */
+    initializeEncryption: (password: string, userId: string, householdId: string) => Promise<boolean>;
     unlockWithPassword: (password: string, userId: string) => Promise<boolean>;
+    setupVaultFromInvite: (params: SetupVaultFromInviteParams) => Promise<boolean>;
 
-    /**
-     * Lock the vault (clear DEK from memory).
-     */
     lockVault: () => void;
-
-    /**
-     * Change password - re-encrypt DEK with new password.
-     */
     changePassword: (oldPassword: string, newPassword: string, userId: string) => Promise<boolean>;
-
-    /**
-     * Reset inactivity timer (called on user activity).
-     */
     resetInactivityTimer: () => void;
 
-    // Two-step so persist happens only after the user has actually saved the code.
     prepareRecoveryCode: () => Promise<PreparedRecoverySlot | null>;
     persistRecoveryCode: (userId: string, slot: PreparedRecoverySlot) => Promise<boolean>;
     hasRecoveryCode: (userId: string) => Promise<boolean>;
+    wrapDEKForInvite: (inviteCode: string) => Promise<{ encryptedDEK: string; salt: string; iv: string } | null>;
+
+    /** The household the user has been soft-removed from. Null when no pending exit. */
+    pendingExitHouseholdId: string | null;
+    /** Decrypt a ciphertext using the soft-removed household's DEK. */
+    decryptFromPendingExit: (ciphertext: string) => Promise<string | null>;
+    /** Drop the pending-exit DEK from memory (call after the exit dialog completes). */
+    clearPendingExitDEK: () => void;
 }
 
 export interface PreparedRecoverySlot {
@@ -64,30 +48,57 @@ export interface PreparedRecoverySlot {
     iv: string;
 }
 
+export interface SetupVaultFromInviteParams {
+    userId: string;
+    householdId: string;
+    password: string;
+    inviteCode: string;
+    wrappedDEK: { encryptedDEK: string; dekSalt: string; dekIV: string };
+}
+
 const EncryptionContext = createContext<EncryptionContextValue | null>(null);
 
-// Inactivity timeout in milliseconds (30 minutes)
 const INACTIVITY_TIMEOUT = 30 * 60 * 1000;
-// Warning before lock (60 seconds)
 const LOCK_WARNING_TIME = 60 * 1000;
 
 interface EncryptionProviderProps {
     children: React.ReactNode;
 }
 
+async function resolveActiveHouseholdId(userId: string): Promise<string | null> {
+    const { data, error } = await supabase
+        .from('household_members')
+        .select('household_id, role, pending_exit_at')
+        .eq('user_id', userId);
+    if (error) {
+        console.error('Failed to resolve household_id for vault:', error);
+        return null;
+    }
+    if (!data || data.length === 0) return null;
+    const active = data.filter((m: any) => !m.pending_exit_at);
+    // If every membership is pending exit, the user has nowhere active to
+    // land — return null and let the caller bootstrap a personal household.
+    if (active.length === 0) return null;
+    const chosen = active.find((m: any) => m.role === 'member') ?? active.find((m: any) => m.role === 'owner') ?? active[0];
+    return chosen?.household_id ?? null;
+}
+
 export function EncryptionProvider({ children }: EncryptionProviderProps) {
-    // DEK stored only in memory - never persisted!
     const dekRef = useRef<CryptoKey | null>(null);
+    // The user the in-memory DEK belongs to. Lets the auth-change listener
+    // distinguish "stale DEK from a different user" (lock) from "DEK just set
+    // up for the user we're transitioning into" (don't lock).
+    const dekUserIdRef = useRef<string | null>(null);
+    const pendingExitDekRef = useRef<CryptoKey | null>(null);
+    const [pendingExitHouseholdId, setPendingExitHouseholdId] = useState<string | null>(null);
     const [isUnlocked, setIsUnlocked] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
 
-    // Inactivity tracking
     const inactivityTimerRef = useRef<NodeJS.Timeout | null>(null);
     const warningTimerRef = useRef<NodeJS.Timeout | null>(null);
     const [showLockWarning, setShowLockWarning] = useState(false);
     const autoLockDisabledRef = useRef(false);
 
-    // Clear timers on unmount
     useEffect(() => {
         return () => {
             if (inactivityTimerRef.current) clearTimeout(inactivityTimerRef.current);
@@ -95,38 +106,52 @@ export function EncryptionProvider({ children }: EncryptionProviderProps) {
         };
     }, []);
 
-    // Auto-unlock vault for demo mode on app load
+    // Drop the DEK whenever it belongs to a different user than the current session.
+    useEffect(() => {
+        const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+            const nextId = session?.user?.id ?? null;
+            if (dekUserIdRef.current && dekUserIdRef.current !== nextId) {
+                dekRef.current = null;
+                dekUserIdRef.current = null;
+                pendingExitDekRef.current = null;
+                setPendingExitHouseholdId(null);
+                setIsUnlocked(false);
+            }
+        });
+        return () => subscription.unsubscribe();
+    }, []);
+
     useEffect(() => {
         const autoUnlockDemo = async () => {
-            // Import here to avoid circular dependency
             const { isDemoMode } = await import('@/utils/demoMode');
 
-            // Only auto-unlock if: demo mode + vault locked + password available
             const demoPassword = sessionStorage.getItem('demo_password');
             if (!isDemoMode() || isUnlocked || !demoPassword) {
                 return;
             }
 
-            // Need user ID from auth
             const authData = await supabase.auth.getUser();
             if (!authData.data.user) return;
 
-            console.log('Auto-unlocking demo vault...');
-            // Import the unlock function from encryption service
+            const userId = authData.data.user.id;
+            const householdId = await resolveActiveHouseholdId(userId);
+            if (!householdId) return;
+
             const { unlockVault: unlockFn } = await import('@/services/encryption');
 
             try {
                 const { data: vault } = await (supabase as any)
                     .from('user_vault_keys')
                     .select('encrypted_dek, dek_salt, dek_iv')
-                    .eq('user_id', authData.data.user.id)
-                    .single();
+                    .eq('user_id', userId)
+                    .eq('household_id', householdId)
+                    .maybeSingle();
 
                 if (vault?.encrypted_dek) {
                     const dek = await unlockFn(demoPassword, vault.encrypted_dek, vault.dek_salt, vault.dek_iv);
                     dekRef.current = dek;
+                    dekUserIdRef.current = userId;
                     setIsUnlocked(true);
-                    console.log('Demo vault auto-unlocked successfully');
                 }
             } catch (error) {
                 console.warn('Demo vault auto-unlock failed:', error);
@@ -134,9 +159,8 @@ export function EncryptionProvider({ children }: EncryptionProviderProps) {
         };
 
         autoUnlockDemo();
-    }, [isUnlocked]); // Re-run if unlock status changes
+    }, [isUnlocked]);
 
-    // Reset inactivity timer
     const resetInactivityTimer = useCallback(() => {
         setShowLockWarning(false);
 
@@ -145,17 +169,15 @@ export function EncryptionProvider({ children }: EncryptionProviderProps) {
 
         if (!isUnlocked || autoLockDisabledRef.current) return;
 
-        // Set warning timer (fires before lock) - show toast
         warningTimerRef.current = setTimeout(() => {
             setShowLockWarning(true);
             toast({
                 title: 'Vault Auto-Lock Warning',
                 description: 'You have been inactive. The vault will lock in 1 minute. Interact with the app to stay active.',
-                duration: 55000, // Show for almost the full minute
+                duration: 55000,
             });
         }, INACTIVITY_TIMEOUT - LOCK_WARNING_TIME);
 
-        // Set lock timer
         inactivityTimerRef.current = setTimeout(() => {
             if (!autoLockDisabledRef.current) {
                 lockVault();
@@ -168,16 +190,32 @@ export function EncryptionProvider({ children }: EncryptionProviderProps) {
         }, INACTIVITY_TIMEOUT);
     }, [isUnlocked]);
 
-    // Lock vault - clear DEK from memory
     const lockVault = useCallback(() => {
         dekRef.current = null;
+        dekUserIdRef.current = null;
+        pendingExitDekRef.current = null;
+        setPendingExitHouseholdId(null);
         setIsUnlocked(false);
         setShowLockWarning(false);
         if (inactivityTimerRef.current) clearTimeout(inactivityTimerRef.current);
         if (warningTimerRef.current) clearTimeout(warningTimerRef.current);
     }, []);
 
-    // Encrypt a value
+    const decryptFromPendingExit = useCallback(async (ciphertext: string): Promise<string | null> => {
+        if (!pendingExitDekRef.current) return null;
+        try {
+            return await decryptValue(ciphertext, pendingExitDekRef.current);
+        } catch (err) {
+            console.error('Failed to decrypt pending-exit ciphertext:', err);
+            return null;
+        }
+    }, []);
+
+    const clearPendingExitDEK = useCallback(() => {
+        pendingExitDekRef.current = null;
+        setPendingExitHouseholdId(null);
+    }, []);
+
     const encrypt = useCallback(async (plaintext: string): Promise<string | null> => {
         if (!dekRef.current) {
             console.warn('Encryption attempted while vault is locked');
@@ -191,7 +229,6 @@ export function EncryptionProvider({ children }: EncryptionProviderProps) {
         }
     }, []);
 
-    // Decrypt a value
     const decrypt = useCallback(async (ciphertext: string): Promise<string | null> => {
         if (!dekRef.current) {
             console.warn('Decryption attempted while vault is locked');
@@ -205,8 +242,11 @@ export function EncryptionProvider({ children }: EncryptionProviderProps) {
         }
     }, []);
 
-    // Initialize encryption for new user
-    const initializeEncryption = useCallback(async (password: string, userId: string): Promise<boolean> => {
+    const initializeEncryption = useCallback(async (
+        password: string,
+        userId: string,
+        householdId: string,
+    ): Promise<boolean> => {
         setIsLoading(true);
         try {
             const { encryptedDEK, dekSalt, dekIV, dek } = await createUserEncryptionKeys(password);
@@ -215,6 +255,7 @@ export function EncryptionProvider({ children }: EncryptionProviderProps) {
                 .from('user_vault_keys')
                 .upsert({
                     user_id: userId,
+                    household_id: householdId,
                     encrypted_dek: encryptedDEK,
                     dek_salt: dekSalt,
                     dek_iv: dekIV,
@@ -226,8 +267,8 @@ export function EncryptionProvider({ children }: EncryptionProviderProps) {
                 return false;
             }
 
-            // Store DEK in memory
             dekRef.current = dek;
+            dekUserIdRef.current = userId;
             setIsUnlocked(true);
             resetInactivityTimer();
 
@@ -240,14 +281,26 @@ export function EncryptionProvider({ children }: EncryptionProviderProps) {
         }
     }, [resetInactivityTimer]);
 
-    // Unlock vault with password
     const unlockWithPassword = useCallback(async (password: string, userId: string): Promise<boolean> => {
         setIsLoading(true);
         try {
+            let householdId = await resolveActiveHouseholdId(userId);
+            if (!householdId) {
+                // Stranded user (e.g. removed from the only household they joined).
+                // Provision a personal household via the RPC and continue.
+                const { data: bootstrappedId, error: bootstrapError } = await (supabase as any).rpc('ensure_user_has_household');
+                if (bootstrapError || !bootstrappedId) {
+                    console.error('Failed to provision a household for stranded user:', bootstrapError);
+                    return false;
+                }
+                householdId = bootstrappedId as string;
+            }
+
             const { data: vault, error } = await (supabase as any)
                 .from('user_vault_keys')
                 .select('encrypted_dek, dek_salt, dek_iv')
                 .eq('user_id', userId)
+                .eq('household_id', householdId)
                 .maybeSingle();
 
             if (error) {
@@ -255,21 +308,61 @@ export function EncryptionProvider({ children }: EncryptionProviderProps) {
                 return false;
             }
 
-            if (!vault || !vault.encrypted_dek || !vault.dek_salt || !vault.dek_iv) {
-                return await initializeEncryption(password, userId);
+            if (!vault?.encrypted_dek) {
+                // Only auto-init when nobody in the household has a wrap yet —
+                // otherwise we'd fork the DEK and orphan existing data.
+                const { data: hasKeys } = await (supabase as any).rpc('household_has_any_vault_keys', {
+                    household_id_in: householdId,
+                });
+                if (hasKeys === false) {
+                    return await initializeEncryption(password, userId, householdId);
+                }
+                return false;
             }
 
             const dek = await unlockVault(
                 password,
                 vault.encrypted_dek,
                 vault.dek_salt,
-                vault.dek_iv
+                vault.dek_iv,
             );
 
-            // Store DEK in memory
             dekRef.current = dek;
+            dekUserIdRef.current = userId;
             setIsUnlocked(true);
             resetInactivityTimer();
+
+            // Also unlock any pending-exit household so the exit dialog can
+            // decrypt the old household's items for duplication.
+            const { data: pendingMembership } = await (supabase as any)
+                .from('household_members')
+                .select('household_id')
+                .eq('user_id', userId)
+                .not('pending_exit_at', 'is', null)
+                .limit(1)
+                .maybeSingle();
+            if (pendingMembership?.household_id) {
+                const { data: pendingVault } = await (supabase as any)
+                    .from('user_vault_keys')
+                    .select('encrypted_dek, dek_salt, dek_iv')
+                    .eq('user_id', userId)
+                    .eq('household_id', pendingMembership.household_id)
+                    .maybeSingle();
+                if (pendingVault?.encrypted_dek) {
+                    try {
+                        const pendingDek = await unlockVault(
+                            password,
+                            pendingVault.encrypted_dek,
+                            pendingVault.dek_salt,
+                            pendingVault.dek_iv,
+                        );
+                        pendingExitDekRef.current = pendingDek;
+                        setPendingExitHouseholdId(pendingMembership.household_id);
+                    } catch (err) {
+                        console.error('Failed to unlock pending-exit vault:', err);
+                    }
+                }
+            }
 
             return true;
         } catch (error) {
@@ -278,20 +371,73 @@ export function EncryptionProvider({ children }: EncryptionProviderProps) {
         } finally {
             setIsLoading(false);
         }
-    }, [initializeEncryption, resetInactivityTimer]);
+    }, [resetInactivityTimer, initializeEncryption]);
 
-    // Change password
+    const setupVaultFromInvite = useCallback(async ({
+        userId,
+        householdId,
+        password,
+        inviteCode,
+        wrappedDEK,
+    }: SetupVaultFromInviteParams): Promise<boolean> => {
+        setIsLoading(true);
+        try {
+            const dek = await unwrapDEKWithInviteCode(
+                wrappedDEK.encryptedDEK,
+                wrappedDEK.dekSalt,
+                wrappedDEK.dekIV,
+                inviteCode,
+            );
+
+            const { encryptedDEK, dekSalt, dekIV } = await rewrapDEKWithPassword(dek, password);
+
+            const { error } = await (supabase as any)
+                .from('user_vault_keys')
+                .upsert({
+                    user_id: userId,
+                    household_id: householdId,
+                    encrypted_dek: encryptedDEK,
+                    dek_salt: dekSalt,
+                    dek_iv: dekIV,
+                    encryption_version: 1,
+                });
+
+            if (error) {
+                console.error('Failed to store invite-derived vault key:', error);
+                return false;
+            }
+
+            dekRef.current = dek;
+            dekUserIdRef.current = userId;
+            setIsUnlocked(true);
+            resetInactivityTimer();
+            return true;
+        } catch (error) {
+            console.error('Failed to set up vault from invite:', error);
+            return false;
+        } finally {
+            setIsLoading(false);
+        }
+    }, [resetInactivityTimer]);
+
     const changePassword = useCallback(async (
         oldPassword: string,
         newPassword: string,
-        userId: string
+        userId: string,
     ): Promise<boolean> => {
         setIsLoading(true);
         try {
+            const householdId = await resolveActiveHouseholdId(userId);
+            if (!householdId) {
+                console.error('No household membership; cannot change password');
+                return false;
+            }
+
             const { data: vault, error: fetchError } = await (supabase as any)
                 .from('user_vault_keys')
                 .select('encrypted_dek, dek_salt, dek_iv')
                 .eq('user_id', userId)
+                .eq('household_id', householdId)
                 .single();
 
             if (fetchError || !vault?.encrypted_dek) {
@@ -303,7 +449,7 @@ export function EncryptionProvider({ children }: EncryptionProviderProps) {
                 oldPassword,
                 vault.encrypted_dek,
                 vault.dek_salt,
-                vault.dek_iv
+                vault.dek_iv,
             );
 
             const { encryptedDEK, dekSalt, dekIV } = await reEncryptDEK(dek, newPassword);
@@ -315,15 +461,16 @@ export function EncryptionProvider({ children }: EncryptionProviderProps) {
                     dek_salt: dekSalt,
                     dek_iv: dekIV,
                 })
-                .eq('user_id', userId);
+                .eq('user_id', userId)
+                .eq('household_id', householdId);
 
             if (updateError) {
                 console.error('Failed to update encryption keys:', updateError);
                 return false;
             }
 
-            // Update DEK in memory
             dekRef.current = dek;
+            dekUserIdRef.current = userId;
             setIsUnlocked(true);
 
             return true;
@@ -352,7 +499,6 @@ export function EncryptionProvider({ children }: EncryptionProviderProps) {
 
     const persistRecoveryCode = useCallback(async (userId: string, slot: PreparedRecoverySlot): Promise<boolean> => {
         try {
-            // Partial unique index can't drive ON CONFLICT, hence the delete+insert.
             await (supabase as any)
                 .from('user_vault_recovery_slots')
                 .delete()
@@ -380,6 +526,19 @@ export function EncryptionProvider({ children }: EncryptionProviderProps) {
         }
     }, []);
 
+    const wrapDEKForInvite = useCallback(async (inviteCode: string) => {
+        if (!dekRef.current) {
+            console.warn('Cannot wrap DEK for invite: vault is locked');
+            return null;
+        }
+        try {
+            return await wrapDEKWithInviteCode(dekRef.current, inviteCode);
+        } catch (err) {
+            console.error('Failed to wrap DEK with invite code:', err);
+            return null;
+        }
+    }, []);
+
     const hasRecoveryCode = useCallback(async (userId: string): Promise<boolean> => {
         const { data, error } = await (supabase as any)
             .from('user_vault_recovery_slots')
@@ -401,17 +560,19 @@ export function EncryptionProvider({ children }: EncryptionProviderProps) {
         decrypt,
         initializeEncryption,
         unlockWithPassword,
+        setupVaultFromInvite,
         lockVault,
         changePassword,
         resetInactivityTimer,
         prepareRecoveryCode,
         persistRecoveryCode,
         hasRecoveryCode,
+        wrapDEKForInvite,
+        pendingExitHouseholdId,
+        decryptFromPendingExit,
+        clearPendingExitDEK,
     };
 
-    // --- Developer Mode: Disable Auto-Lock ---
-    // Expose functions to window for developers to control auto-lock
-    // Usage in console: window.disableVaultAutoLock() / window.enableVaultAutoLock()
     useEffect(() => {
         if (process.env.NODE_ENV === 'development') {
             (window as any).disableVaultAutoLock = () => {
@@ -427,12 +588,10 @@ export function EncryptionProvider({ children }: EncryptionProviderProps) {
             };
         }
     }, [resetInactivityTimer]);
-    // -----------------------------------------
 
     return (
         <EncryptionContext.Provider value={value}>
             {children}
-            {/* Lock Warning Modal */}
             {showLockWarning && (
                 <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
                     <div className="bg-background border border-border rounded-lg p-6 max-w-md mx-4 shadow-xl">

--- a/frontend/src/contexts/HouseholdContext.tsx
+++ b/frontend/src/contexts/HouseholdContext.tsx
@@ -1,7 +1,8 @@
-import { createContext, useContext, useEffect, useState, ReactNode, useCallback } from "react";
+import { createContext, useContext, useEffect, useRef, useState, ReactNode, useCallback } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "./AuthContext";
 import { getActiveHousehold } from "@/utils/householdHelpers";
+import { toast } from "@/hooks/use-toast";
 
 // Types
 export interface Household {
@@ -55,8 +56,17 @@ export const HouseholdProvider = ({ children }: { children: ReactNode }) => {
     const [loading, setLoading] = useState(true);
 
     const userId = user?.id;
+    // Concurrent fetches (e.g. an effect-triggered refetch racing the wizard's
+    // explicit refresh) would otherwise let a stale empty result overwrite a
+    // fresh complete one.
+    const fetchGenRef = useRef(0);
+
     const fetchHouseholdData = useCallback(async () => {
+        const gen = ++fetchGenRef.current;
+        const isLatest = () => gen === fetchGenRef.current;
+
         if (!userId) {
+            if (!isLatest()) return;
             setHousehold(null);
             setMembers([]);
             setCoParents([]);
@@ -66,17 +76,18 @@ export const HouseholdProvider = ({ children }: { children: ReactNode }) => {
         }
 
         try {
-            // Get active household
             const { membership, household: householdData } = await getActiveHousehold(userId);
+            if (!isLatest()) return;
 
             if (!membership || !householdData) {
+                setHousehold(null);
+                setMembers([]);
+                setCoParents([]);
+                setUserRole("");
                 setLoading(false);
                 return;
             }
 
-            setUserRole(membership.role);
-
-            // Fetch complete household data with all related info
             const [
                 { data: fullHousehold },
                 { data: membersData },
@@ -96,21 +107,56 @@ export const HouseholdProvider = ({ children }: { children: ReactNode }) => {
                     .select("*")
                     .eq("household_id", membership.household_id),
             ]);
+            if (!isLatest()) return;
 
+            setUserRole(membership.role);
             setHousehold(fullHousehold as Household);
             setMembers((membersData || []) as HouseholdMember[]);
             setCoParents((coParentsData || []) as CoParent[]);
         } catch (error) {
             console.error("Error fetching household data:", error);
         } finally {
-            setLoading(false);
+            if (isLatest()) setLoading(false);
         }
     }, [userId]);
 
-    // Fetch on user change
     useEffect(() => {
+        // Reset loading so consumers re-show skeletons across the userId boundary.
+        setLoading(true);
         fetchHouseholdData();
     }, [fetchHouseholdData]);
+
+    // Live notification: if an owner soft-removes the current user, reload
+    // so they land in the exit-dialog flow instead of continuing to write to
+    // a household they no longer belong to.
+    useEffect(() => {
+        if (!userId) return;
+        const channel = supabase
+            .channel(`household_members:${userId}`)
+            .on(
+                "postgres_changes",
+                {
+                    event: "UPDATE",
+                    schema: "public",
+                    table: "household_members",
+                    filter: `user_id=eq.${userId}`,
+                },
+                (payload) => {
+                    const oldPending = (payload.old as any)?.pending_exit_at ?? null;
+                    const newPending = (payload.new as any)?.pending_exit_at ?? null;
+                    if (!oldPending && newPending) {
+                        toast({
+                            title: "You've been removed",
+                            description: "Reloading so you can pick which items to bring with you…",
+                            variant: "destructive",
+                        });
+                        setTimeout(() => window.location.reload(), 3000);
+                    }
+                },
+            )
+            .subscribe();
+        return () => { supabase.removeChannel(channel); };
+    }, [userId]);
 
     // Computed value
     const financialMonthStart = household?.financial_month_start || 25;

--- a/frontend/src/hooks/useEntityForm.ts
+++ b/frontend/src/hooks/useEntityForm.ts
@@ -8,8 +8,10 @@ interface UseEntityFormOpts {
     save: () => Promise<void>;
     /** Omit when not in edit mode or delete isn't supported. */
     remove?: () => Promise<void>;
-    /** Called after a successful save. Parent typically refetches + closes. */
+    /** Called after a successful save. Parent typically refetches the list. */
     onSaved?: () => void;
+    /** Called after save when the dialog should close (i.e. not staying open for "Create another"). */
+    onClose?: () => void;
     /** Called after a successful delete. */
     onDeleted?: () => void;
     /** Reset form fields to blank — used when "Create another" is checked. */
@@ -26,6 +28,7 @@ export function useEntityForm({
     save,
     remove,
     onSaved,
+    onClose,
     onDeleted,
     resetForm,
     formValues,
@@ -48,7 +51,11 @@ export function useEntityForm({
             await save();
             toast.success(`${entityName} ${isEdit ? "updated" : "added"}`);
             onSaved?.();
-            if (!isEdit && createAnother) resetForm?.();
+            if (!isEdit && createAnother) {
+                resetForm?.();
+            } else {
+                onClose?.();
+            }
         } catch (err: any) {
             toast.error(err?.message || `Failed to save ${lower}`);
         } finally {

--- a/frontend/src/integrations/supabase/types.ts
+++ b/frontend/src/integrations/supabase/types.ts
@@ -13,31 +13,6 @@ export type Database = {
   __InternalSupabase: {
     PostgrestVersion: "13.0.5"
   }
-  graphql_public: {
-    Tables: {
-      [_ in never]: never
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      graphql: {
-        Args: {
-          extensions?: Json
-          operationName?: string
-          query?: string
-          variables?: Json
-        }
-        Returns: Json
-      }
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
-    }
-  }
   public: {
     Tables: {
       co_parent_settlements: {
@@ -297,6 +272,9 @@ export type Database = {
         Row: {
           created_at: string
           created_by: string
+          dek_iv: string | null
+          dek_salt: string | null
+          encrypted_dek: string | null
           expires_at: string
           household_id: string
           id: string
@@ -308,6 +286,9 @@ export type Database = {
         Insert: {
           created_at?: string
           created_by: string
+          dek_iv?: string | null
+          dek_salt?: string | null
+          encrypted_dek?: string | null
           expires_at: string
           household_id: string
           id?: string
@@ -319,6 +300,9 @@ export type Database = {
         Update: {
           created_at?: string
           created_by?: string
+          dek_iv?: string | null
+          dek_salt?: string | null
+          encrypted_dek?: string | null
           expires_at?: string
           household_id?: string
           id?: string
@@ -349,6 +333,7 @@ export type Database = {
           household_id: string
           id: string
           joined_at: string
+          pending_exit_at: string | null
           role: Database["public"]["Enums"]["household_role"]
           user_id: string
         }
@@ -356,6 +341,7 @@ export type Database = {
           household_id: string
           id?: string
           joined_at?: string
+          pending_exit_at?: string | null
           role: Database["public"]["Enums"]["household_role"]
           user_id: string
         }
@@ -363,6 +349,7 @@ export type Database = {
           household_id?: string
           id?: string
           joined_at?: string
+          pending_exit_at?: string | null
           role?: Database["public"]["Enums"]["household_role"]
           user_id?: string
         }
@@ -386,35 +373,35 @@ export type Database = {
       households: {
         Row: {
           created_at: string
-          owner_id: string
           currency: string
           enable_credit_cards: boolean | null
           enable_shared_expenses: boolean | null
           financial_month_start: number | null
           id: string
           name: string
+          owner_id: string
           updated_at: string
         }
         Insert: {
           created_at?: string
-          owner_id: string
           currency?: string
           enable_credit_cards?: boolean | null
           enable_shared_expenses?: boolean | null
           financial_month_start?: number | null
           id?: string
           name: string
+          owner_id: string
           updated_at?: string
         }
         Update: {
           created_at?: string
-          owner_id?: string
           currency?: string
           enable_credit_cards?: boolean | null
           enable_shared_expenses?: boolean | null
           financial_month_start?: number | null
           id?: string
           name?: string
+          owner_id?: string
           updated_at?: string
         }
         Relationships: [
@@ -432,7 +419,6 @@ export type Database = {
           category: Database["public"]["Enums"]["income_category_enum"]
           co_parent_id: string | null
           created_at: string
-          owner_id: string
           custom_tax_rate: number | null
           encrypted_default_amount: string | null
           encrypted_name: string | null
@@ -442,6 +428,7 @@ export type Database = {
           is_active: boolean
           is_encrypted: boolean | null
           is_shared: boolean | null
+          owner_id: string
           share_percentage: number | null
           tax_type: Database["public"]["Enums"]["tax_type"] | null
           updated_at: string
@@ -450,7 +437,6 @@ export type Database = {
           category: Database["public"]["Enums"]["income_category_enum"]
           co_parent_id?: string | null
           created_at?: string
-          owner_id: string
           custom_tax_rate?: number | null
           encrypted_default_amount?: string | null
           encrypted_name?: string | null
@@ -460,6 +446,7 @@ export type Database = {
           is_active?: boolean
           is_encrypted?: boolean | null
           is_shared?: boolean | null
+          owner_id: string
           share_percentage?: number | null
           tax_type?: Database["public"]["Enums"]["tax_type"] | null
           updated_at?: string
@@ -468,7 +455,6 @@ export type Database = {
           category?: Database["public"]["Enums"]["income_category_enum"]
           co_parent_id?: string | null
           created_at?: string
-          owner_id?: string
           custom_tax_rate?: number | null
           encrypted_default_amount?: string | null
           encrypted_name?: string | null
@@ -478,6 +464,7 @@ export type Database = {
           is_active?: boolean
           is_encrypted?: boolean | null
           is_shared?: boolean | null
+          owner_id?: string
           share_percentage?: number | null
           tax_type?: Database["public"]["Enums"]["tax_type"] | null
           updated_at?: string
@@ -508,6 +495,9 @@ export type Database = {
       }
       insurances: {
         Row: {
+          billing_cycle: Database["public"]["Enums"]["billing_cycle_enum"]
+          billing_day: number | null
+          billing_month: number | null
           category: Database["public"]["Enums"]["insurance_category_enum"]
           co_parent_id: string | null
           created_at: string
@@ -517,18 +507,18 @@ export type Database = {
           encrypted_total_amount: string | null
           household_id: string
           id: string
-          billing_month: number | null
-          billing_day: number | null
           is_active: boolean
           is_encrypted: boolean | null
           is_shared: boolean
           notes: string | null
-          billing_cycle: Database["public"]["Enums"]["billing_cycle_enum"]
           share_percentage: number
           subject_id: string | null
           updated_at: string
         }
         Insert: {
+          billing_cycle?: Database["public"]["Enums"]["billing_cycle_enum"]
+          billing_day?: number | null
+          billing_month?: number | null
           category: Database["public"]["Enums"]["insurance_category_enum"]
           co_parent_id?: string | null
           created_at?: string
@@ -538,18 +528,18 @@ export type Database = {
           encrypted_total_amount?: string | null
           household_id: string
           id?: string
-          billing_month?: number | null
-          billing_day?: number | null
           is_active?: boolean
           is_encrypted?: boolean | null
           is_shared?: boolean
           notes?: string | null
-          billing_cycle?: Database["public"]["Enums"]["billing_cycle_enum"]
           share_percentage?: number
           subject_id?: string | null
           updated_at?: string
         }
         Update: {
+          billing_cycle?: Database["public"]["Enums"]["billing_cycle_enum"]
+          billing_day?: number | null
+          billing_month?: number | null
           category?: Database["public"]["Enums"]["insurance_category_enum"]
           co_parent_id?: string | null
           created_at?: string
@@ -559,13 +549,10 @@ export type Database = {
           encrypted_total_amount?: string | null
           household_id?: string
           id?: string
-          billing_month?: number | null
-          billing_day?: number | null
           is_active?: boolean
           is_encrypted?: boolean | null
           is_shared?: boolean
           notes?: string | null
-          billing_cycle?: Database["public"]["Enums"]["billing_cycle_enum"]
           share_percentage?: number
           subject_id?: string | null
           updated_at?: string
@@ -1174,42 +1161,6 @@ export type Database = {
           },
         ]
       }
-      user_vault_recovery_slots: {
-        Row: {
-          id: string
-          user_id: string
-          slot_type: string
-          encrypted_dek: string
-          salt: string | null
-          iv: string
-          label: string | null
-          granted_by_user_id: string | null
-          created_at: string
-        }
-        Insert: {
-          id?: string
-          user_id: string
-          slot_type: string
-          encrypted_dek: string
-          salt?: string | null
-          iv: string
-          label?: string | null
-          granted_by_user_id?: string | null
-          created_at?: string
-        }
-        Update: {
-          id?: string
-          user_id?: string
-          slot_type?: string
-          encrypted_dek?: string
-          salt?: string | null
-          iv?: string
-          label?: string | null
-          granted_by_user_id?: string | null
-          created_at?: string
-        }
-        Relationships: []
-      }
       user_vault_keys: {
         Row: {
           created_at: string
@@ -1217,6 +1168,7 @@ export type Database = {
           dek_salt: string
           encrypted_dek: string
           encryption_version: number
+          household_id: string
           updated_at: string
           user_id: string
         }
@@ -1226,6 +1178,7 @@ export type Database = {
           dek_salt: string
           encrypted_dek: string
           encryption_version?: number
+          household_id: string
           updated_at?: string
           user_id: string
         }
@@ -1235,7 +1188,52 @@ export type Database = {
           dek_salt?: string
           encrypted_dek?: string
           encryption_version?: number
+          household_id?: string
           updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_vault_keys_household_id_fkey"
+            columns: ["household_id"]
+            isOneToOne: false
+            referencedRelation: "households"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      user_vault_recovery_slots: {
+        Row: {
+          created_at: string
+          encrypted_dek: string
+          granted_by_user_id: string | null
+          id: string
+          iv: string
+          label: string | null
+          salt: string | null
+          slot_type: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          encrypted_dek: string
+          granted_by_user_id?: string | null
+          id?: string
+          iv: string
+          label?: string | null
+          salt?: string | null
+          slot_type: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          encrypted_dek?: string
+          granted_by_user_id?: string | null
+          id?: string
+          iv?: string
+          label?: string | null
+          salt?: string | null
+          slot_type?: string
           user_id?: string
         }
         Relationships: []
@@ -1245,7 +1243,21 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      confirm_member_exit: { Args: never; Returns: undefined }
+      ensure_user_has_household: { Args: never; Returns: string }
       get_user_household_id: { Args: { _user_id: string }; Returns: string }
+      handle_owner_leave: {
+        Args: { successor_user_id_in: string }
+        Returns: undefined
+      }
+      household_has_any_vault_keys: {
+        Args: { household_id_in: string }
+        Returns: boolean
+      }
+      is_active_household_member: {
+        Args: { _household_id: string; _user_id: string }
+        Returns: boolean
+      }
       is_email_whitelisted: { Args: { email_in: string }; Returns: boolean }
       is_household_member: {
         Args: { _household_id: string; _user_id: string }
@@ -1257,6 +1269,11 @@ export type Database = {
       }
       lookup_active_invite: { Args: { invite_code_in: string }; Returns: Json }
       redeem_invite: { Args: { invite_code_in: string }; Returns: Json }
+      request_member_exit: {
+        Args: { member_id_in: string }
+        Returns: undefined
+      }
+      sweep_pending_exits: { Args: never; Returns: number }
     }
     Enums: {
       billing_cycle_enum: "monthly" | "quarterly" | "semi_annually" | "yearly"
@@ -1451,9 +1468,6 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
-  graphql_public: {
-    Enums: {},
-  },
   public: {
     Enums: {
       billing_cycle_enum: ["monthly", "quarterly", "semi_annually", "yearly"],
@@ -1533,4 +1547,5 @@ export const Constants = {
     },
   },
 } as const
-<claude-code-hint v="1" type="plugin" value="supabase@claude-plugins-official" />
+A new version of Supabase CLI is available: v2.98.2 (currently installed v2.84.2)
+We recommend updating regularly for new features and bug fixes: https://supabase.com/docs/guides/cli/getting-started#updating-the-supabase-cli

--- a/frontend/src/pages/Auth.tsx
+++ b/frontend/src/pages/Auth.tsx
@@ -15,6 +15,7 @@ import { PLACEHOLDERS } from "@/constants/ui";
 import { isEmailAllowed } from "@/config/emailWhitelist";
 import { passwordSchema } from "@/config/passwordSchema";
 import { setDemoMode } from "@/utils/demoMode";
+import { supabase } from "@/integrations/supabase/client";
 
 // Feature flag: demo mode is hidden until the monthly review flow is rebuilt
 const DEMO_ENABLED = false;
@@ -123,8 +124,9 @@ const Auth = () => {
 
   // ─── Auto-redirect + email confirm hash handling ──────────
   useEffect(() => {
-    if (user) navigate("/", { replace: true });
-  }, [user, navigate]);
+    // The join wizard makes `user` truthy mid-flow; wait for it to finish.
+    if (user && !showJoinDialog) navigate("/", { replace: true });
+  }, [user, navigate, showJoinDialog]);
 
   useEffect(() => {
     const hash = window.location.hash;
@@ -223,7 +225,25 @@ const Auth = () => {
       }
 
       if (data?.user) {
-        const encryptionInitialized = await initializeEncryption(password, data.user.id);
+        // The signup trigger's household insert can briefly trail the auth response — poll until visible.
+        let householdId: string | null = null;
+        for (let attempt = 0; attempt < 5; attempt++) {
+          const { data: membership } = await supabase
+            .from("household_members")
+            .select("household_id")
+            .eq("user_id", data.user.id)
+            .limit(1)
+            .maybeSingle();
+          if (membership?.household_id) {
+            householdId = membership.household_id;
+            break;
+          }
+          await new Promise((r) => setTimeout(r, 250));
+        }
+
+        const encryptionInitialized = householdId
+          ? await initializeEncryption(password, data.user.id, householdId)
+          : false;
         if (encryptionInitialized) {
           toast({
             title: "Account Created & Secured!",

--- a/frontend/src/pages/Expenses.tsx
+++ b/frontend/src/pages/Expenses.tsx
@@ -41,7 +41,8 @@ const Expenses = () => {
   const { user } = useAuth();
   const { household, members, coParents } = useHousehold();
   const { isUnlocked } = useEncryption();
-  const subjects = useHouseholdSubjects(household?.id);
+  const [subjectsRefreshKey, setSubjectsRefreshKey] = useState(0);
+  const subjects = useHouseholdSubjects(household?.id, subjectsRefreshKey);
   const earliestDataMonth = useEarliestDataMonth(household?.id);
   const [expenseCategories, setExpenseCategories] = useState<any[]>([]);
   const [monthlyExpenses, setMonthlyExpenses] = useState<any[]>([]);
@@ -107,6 +108,9 @@ const Expenses = () => {
 
   const fetchData = useCallback(async () => {
     if (!user || !household) return;
+
+    // Forms may have created new subjects inline (SubjectPicker "+"); re-fetch them.
+    setSubjectsRefreshKey(k => k + 1);
 
     // If vault is locked, we can't fetch decrypted data safely
     if (!isUnlocked) {

--- a/frontend/src/pages/Overview.tsx
+++ b/frontend/src/pages/Overview.tsx
@@ -75,7 +75,7 @@ interface OverviewData {
 const Dashboard = () => {
   const { user } = useAuth();
   const { household, coParents, members, financialMonthStart, loading: householdLoading } = useHousehold();
-  const { isUnlocked, encrypt, decrypt } = useEncryption();
+  const { isUnlocked, encrypt, decrypt, pendingExitHouseholdId } = useEncryption();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const [loading, setLoading] = useState(true);
@@ -346,7 +346,10 @@ const Dashboard = () => {
 
       const setupDone = localStorage.getItem(`hh_setup_done_${household.id}`) === "1";
       const explicitOpen = searchParams.get("setup") === "1";
-      if (explicitOpen || (!hasSeed && !setupDone)) {
+      // The exit dialog owns the welcome experience while a pending exit is unresolved.
+      if (pendingExitHouseholdId) {
+        setSetupOpen(false);
+      } else if (explicitOpen || (!hasSeed && !setupDone)) {
         setSetupOpen(true);
       } else if (hasSeed) {
         localStorage.setItem(`hh_setup_done_${household.id}`, "1");
@@ -357,7 +360,7 @@ const Dashboard = () => {
       }
     };
     checkSeedData();
-  }, [household?.id, isUnlocked, todayMonth]);
+  }, [household?.id, isUnlocked, todayMonth, pendingExitHouseholdId]);
 
   // ─── Loading + locked states ─────────────────────────────────
   if (householdLoading || loading) {

--- a/frontend/src/services/encryption.ts
+++ b/frontend/src/services/encryption.ts
@@ -300,3 +300,35 @@ export async function unwrapDEKWithRecoveryCode(
     const kek = await deriveKEK(normalizeRecoveryCode(code), salt);
     return decryptDEK(encryptedDEK, iv, kek);
 }
+
+function normalizeInviteCode(code: string): string {
+    return code.trim().toUpperCase();
+}
+
+export async function wrapDEKWithInviteCode(
+    dek: CryptoKey,
+    inviteCode: string,
+): Promise<{ encryptedDEK: string; salt: string; iv: string }> {
+    const salt = generateSalt();
+    const kek = await deriveKEK(normalizeInviteCode(inviteCode), salt);
+    const { encryptedDEK, iv } = await encryptDEK(dek, kek);
+    return { encryptedDEK, salt: arrayBufferToBase64(salt.buffer), iv };
+}
+
+export async function unwrapDEKWithInviteCode(
+    encryptedDEK: string,
+    saltB64: string,
+    iv: string,
+    inviteCode: string,
+): Promise<CryptoKey> {
+    const salt = new Uint8Array(base64ToArrayBuffer(saltB64));
+    const kek = await deriveKEK(normalizeInviteCode(inviteCode), salt);
+    return decryptDEK(encryptedDEK, iv, kek);
+}
+
+export async function rewrapDEKWithPassword(
+    dek: CryptoKey,
+    password: string,
+): Promise<{ encryptedDEK: string; dekSalt: string; dekIV: string }> {
+    return reEncryptDEK(dek, password);
+}

--- a/frontend/src/utils/householdHelpers.ts
+++ b/frontend/src/utils/householdHelpers.ts
@@ -6,6 +6,7 @@ export interface HouseholdMembership {
     user_id: string;
     role: "owner" | "member";
     joined_at: string;
+    pending_exit_at: string | null;
 }
 
 export interface Household {
@@ -48,8 +49,11 @@ export async function getActiveHousehold(userId: string): Promise<ActiveHousehol
         return { membership: null, household: null, allMemberships: [] };
     }
 
-    // Explicitly prioritize member role over owner role (don't rely on alphabetical sorting)
-    const activeMembership = memberships.find(m => m.role === "member") || memberships.find(m => m.role === "owner");
+    // Soft-removed memberships drop to the back — the user has already been
+    // shown the exit dialog (or will be); they shouldn't land in that household.
+    const active = memberships.filter(m => !m.pending_exit_at);
+    const pool = active.length > 0 ? active : memberships;
+    const activeMembership = pool.find(m => m.role === "member") || pool.find(m => m.role === "owner");
 
     if (!activeMembership) {
         console.error("[getActiveHousehold] No valid membership found");

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,1 +1,25 @@
 project_id = "pksyokumflsyvjcmtjmv"
+
+[auth.email.template.confirmation]
+subject = "Confirm your email"
+content_path = "./supabase/templates/confirmation.html"
+
+[auth.email.template.invite]
+subject = "You've been invited to a household"
+content_path = "./supabase/templates/invite.html"
+
+[auth.email.template.magic_link]
+subject = "Your login link"
+content_path = "./supabase/templates/magic_link.html"
+
+[auth.email.template.email_change]
+subject = "Confirm your new email"
+content_path = "./supabase/templates/email_change.html"
+
+[auth.email.template.recovery]
+subject = "Reset your password"
+content_path = "./supabase/templates/recovery.html"
+
+[auth.email.template.reauthentication]
+subject = "Your verification code"
+content_path = "./supabase/templates/reauthentication.html"

--- a/supabase/migrations/20260511250000_household_shared_dek.sql
+++ b/supabase/migrations/20260511250000_household_shared_dek.sql
@@ -1,0 +1,101 @@
+-- Switch encryption from per-user DEK to a household-shared DEK so members
+-- can decrypt each other's data. Old ciphertext was wrapped under per-user
+-- DEKs and is no longer reachable, hence the wipe of encrypted tables.
+TRUNCATE TABLE
+    public.co_parent_settlements,
+    public.co_parents,
+    public.credit_cards,
+    public.expenses,
+    public.household_invites,
+    public.income_sources,
+    public.insurances,
+    public.merchant_categories,
+    public.monthly_expenses,
+    public.monthly_incomes,
+    public.monthly_review_status,
+    public.shared_expenses,
+    public.subjects,
+    public.subscriptions,
+    public.temporary_expenses,
+    public.user_vault_keys,
+    public.user_vault_recovery_slots
+RESTART IDENTITY CASCADE;
+
+ALTER TABLE public.user_vault_keys DROP CONSTRAINT IF EXISTS user_vault_keys_pkey;
+
+ALTER TABLE public.user_vault_keys
+    ADD COLUMN IF NOT EXISTS household_id uuid;
+
+DELETE FROM public.user_vault_keys WHERE household_id IS NULL;
+
+ALTER TABLE public.user_vault_keys
+    ALTER COLUMN household_id SET NOT NULL,
+    ADD CONSTRAINT user_vault_keys_household_id_fkey
+        FOREIGN KEY (household_id) REFERENCES public.households(id) ON DELETE CASCADE,
+    ADD CONSTRAINT user_vault_keys_pkey
+        PRIMARY KEY (user_id, household_id);
+
+CREATE INDEX IF NOT EXISTS idx_user_vault_keys_household
+    ON public.user_vault_keys (household_id);
+
+ALTER TABLE public.household_invites
+    ADD COLUMN IF NOT EXISTS encrypted_dek text,
+    ADD COLUMN IF NOT EXISTS dek_iv        text,
+    ADD COLUMN IF NOT EXISTS dek_salt      text;
+
+CREATE OR REPLACE FUNCTION public.lookup_active_invite(invite_code_in text)
+RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+    SELECT jsonb_build_object(
+        'household_id', h.id,
+        'household_name', h.name,
+        'household_currency', h.currency,
+        'invited_email', hi.invited_email,
+        'encrypted_dek', hi.encrypted_dek,
+        'dek_iv', hi.dek_iv,
+        'dek_salt', hi.dek_salt,
+        'members', COALESCE((
+            SELECT jsonb_agg(
+                jsonb_build_object(
+                    'role', hm.role,
+                    'full_name', p.full_name,
+                    'avatar_url', p.avatar_url
+                )
+                ORDER BY hm.joined_at
+            )
+            FROM household_members hm
+            LEFT JOIN profiles p ON p.id = hm.user_id
+            WHERE hm.household_id = h.id
+        ), '[]'::jsonb)
+    )
+    FROM household_invites hi
+    JOIN households h ON h.id = hi.household_id
+    WHERE upper(hi.invite_code) = upper(invite_code_in)
+      AND hi.is_active = true
+      AND hi.expires_at > now()
+    LIMIT 1;
+$$;
+
+REVOKE ALL ON FUNCTION public.lookup_active_invite(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.lookup_active_invite(text) TO anon, authenticated;
+
+-- Drop a member's wrap when they leave so they can't decrypt household data afterwards.
+CREATE OR REPLACE FUNCTION public.revoke_member_vault_key()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+BEGIN
+    DELETE FROM public.user_vault_keys
+     WHERE user_id      = OLD.user_id
+       AND household_id = OLD.household_id;
+    RETURN OLD;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS revoke_member_vault_key_trg ON public.household_members;
+CREATE TRIGGER revoke_member_vault_key_trg
+    AFTER DELETE ON public.household_members
+    FOR EACH ROW EXECUTE FUNCTION public.revoke_member_vault_key();
+
+REVOKE ALL ON FUNCTION public.revoke_member_vault_key() FROM PUBLIC;

--- a/supabase/migrations/20260511260000_household_has_any_vault_keys.sql
+++ b/supabase/migrations/20260511260000_household_has_any_vault_keys.sql
@@ -1,0 +1,16 @@
+-- Guards the unlock auto-init path: the client must not fork a household's
+-- DEK by initialising a fresh one while another member's wrap still exists.
+
+CREATE OR REPLACE FUNCTION public.household_has_any_vault_keys(household_id_in uuid)
+RETURNS boolean
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+    SELECT EXISTS (
+        SELECT 1
+          FROM public.user_vault_keys
+         WHERE household_id = household_id_in
+    );
+$$;
+
+REVOKE ALL ON FUNCTION public.household_has_any_vault_keys(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.household_has_any_vault_keys(uuid) TO authenticated;

--- a/supabase/migrations/20260511270000_ensure_user_has_household.sql
+++ b/supabase/migrations/20260511270000_ensure_user_has_household.sql
@@ -1,0 +1,43 @@
+-- Fallback for users who end up with zero household memberships (e.g.
+-- invited-only signup followed by removal). Creates a personal household
+-- on demand so login can recover instead of returning an unlockable vault.
+
+CREATE OR REPLACE FUNCTION public.ensure_user_has_household()
+RETURNS uuid
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+    v_user_id      uuid := auth.uid();
+    v_existing     uuid;
+    v_household_id uuid;
+    v_full_name    text;
+BEGIN
+    IF v_user_id IS NULL THEN
+        RAISE EXCEPTION 'not_authenticated';
+    END IF;
+
+    SELECT household_id INTO v_existing
+      FROM public.household_members
+     WHERE user_id = v_user_id
+     LIMIT 1;
+    IF v_existing IS NOT NULL THEN
+        RETURN v_existing;
+    END IF;
+
+    SELECT NULLIF(trim(full_name), '') INTO v_full_name
+      FROM public.profiles
+     WHERE id = v_user_id;
+
+    INSERT INTO public.households (name, currency, owner_id)
+    VALUES (COALESCE(v_full_name, 'My') || '''s Household', 'SEK', v_user_id)
+    RETURNING id INTO v_household_id;
+
+    INSERT INTO public.household_members (household_id, user_id, role)
+    VALUES (v_household_id, v_user_id, 'owner');
+
+    RETURN v_household_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.ensure_user_has_household() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.ensure_user_has_household() TO authenticated;

--- a/supabase/migrations/20260512100000_pending_exit_membership.sql
+++ b/supabase/migrations/20260512100000_pending_exit_membership.sql
@@ -1,0 +1,217 @@
+-- Multi-household exit flow: a member is "soft-removed" by setting
+-- pending_exit_at. While that flag is set their vault key + membership stay
+-- alive so the client can run the duplication dialog. Hard-delete happens
+-- when the user confirms the dialog (confirm_member_exit) or the backstop
+-- job sweeps after the grace period.
+
+ALTER TABLE public.household_members
+    ADD COLUMN IF NOT EXISTS pending_exit_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_household_members_pending_exit_at
+    ON public.household_members (pending_exit_at)
+    WHERE pending_exit_at IS NOT NULL;
+
+-- Helper for future RLS hardening / queries that want to exclude soft-removed
+-- members from "active" sets.
+CREATE OR REPLACE FUNCTION public.is_active_household_member(_user_id uuid, _household_id uuid)
+RETURNS boolean
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+    SELECT EXISTS (
+        SELECT 1
+          FROM public.household_members
+         WHERE user_id        = _user_id
+           AND household_id   = _household_id
+           AND pending_exit_at IS NULL
+    );
+$$;
+
+REVOKE ALL ON FUNCTION public.is_active_household_member(uuid, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.is_active_household_member(uuid, uuid) TO authenticated;
+
+
+-- request_member_exit: caller (household owner or the member themselves)
+-- marks a membership as pending exit. Vault key + membership stay valid.
+CREATE OR REPLACE FUNCTION public.request_member_exit(member_id_in uuid)
+RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+    v_user_id   uuid := auth.uid();
+    v_target    public.household_members%ROWTYPE;
+    v_is_owner  boolean;
+BEGIN
+    IF v_user_id IS NULL THEN
+        RAISE EXCEPTION 'not_authenticated';
+    END IF;
+
+    SELECT * INTO v_target FROM public.household_members WHERE id = member_id_in;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'member_not_found';
+    END IF;
+
+    SELECT EXISTS (
+        SELECT 1 FROM public.households
+         WHERE id = v_target.household_id AND owner_id = v_user_id
+    ) INTO v_is_owner;
+
+    -- Self-leave OR household owner removing someone else.
+    IF v_target.user_id <> v_user_id AND NOT v_is_owner THEN
+        RAISE EXCEPTION 'not_authorized';
+    END IF;
+
+    -- Don't let the household's owner exit while other members still depend
+    -- on them — successor must be promoted first via handle_owner_leave.
+    IF v_target.role = 'owner' AND v_target.user_id = v_user_id THEN
+        IF EXISTS (
+            SELECT 1 FROM public.household_members
+             WHERE household_id = v_target.household_id
+               AND user_id <> v_user_id
+        ) THEN
+            RAISE EXCEPTION 'owner_must_transfer_first';
+        END IF;
+    END IF;
+
+    UPDATE public.household_members
+       SET pending_exit_at = now()
+     WHERE id = member_id_in
+       AND pending_exit_at IS NULL;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.request_member_exit(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.request_member_exit(uuid) TO authenticated;
+
+
+-- confirm_member_exit: caller finalizes their own pending exit. Hard-deletes
+-- the membership (revoke_member_vault_key_trg drops the vault key). If the
+-- household is left empty, it's also deleted.
+CREATE OR REPLACE FUNCTION public.confirm_member_exit()
+RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+    v_user_id      uuid := auth.uid();
+    v_household_id uuid;
+    v_remaining    integer;
+BEGIN
+    IF v_user_id IS NULL THEN
+        RAISE EXCEPTION 'not_authenticated';
+    END IF;
+
+    SELECT household_id INTO v_household_id
+      FROM public.household_members
+     WHERE user_id = v_user_id
+       AND pending_exit_at IS NOT NULL
+     LIMIT 1;
+
+    IF v_household_id IS NULL THEN
+        RAISE EXCEPTION 'no_pending_exit';
+    END IF;
+
+    DELETE FROM public.household_members
+     WHERE user_id      = v_user_id
+       AND household_id = v_household_id;
+
+    SELECT count(*) INTO v_remaining
+      FROM public.household_members
+     WHERE household_id = v_household_id;
+
+    IF v_remaining = 0 THEN
+        DELETE FROM public.households WHERE id = v_household_id;
+    END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.confirm_member_exit() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.confirm_member_exit() TO authenticated;
+
+
+-- handle_owner_leave: owner promotes a successor and sets pending_exit on
+-- their own membership in one atomic step.
+CREATE OR REPLACE FUNCTION public.handle_owner_leave(successor_user_id_in uuid)
+RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+    v_user_id        uuid := auth.uid();
+    v_household_id   uuid;
+    v_successor_ok   boolean;
+BEGIN
+    IF v_user_id IS NULL THEN
+        RAISE EXCEPTION 'not_authenticated';
+    END IF;
+
+    SELECT id INTO v_household_id
+      FROM public.households
+     WHERE owner_id = v_user_id
+     LIMIT 1;
+
+    IF v_household_id IS NULL THEN
+        RAISE EXCEPTION 'not_owner';
+    END IF;
+
+    SELECT EXISTS (
+        SELECT 1 FROM public.household_members
+         WHERE household_id    = v_household_id
+           AND user_id         = successor_user_id_in
+           AND user_id        <> v_user_id
+           AND pending_exit_at IS NULL
+    ) INTO v_successor_ok;
+
+    IF NOT v_successor_ok THEN
+        RAISE EXCEPTION 'invalid_successor';
+    END IF;
+
+    UPDATE public.households
+       SET owner_id = successor_user_id_in
+     WHERE id = v_household_id;
+
+    UPDATE public.household_members
+       SET role = 'owner'
+     WHERE household_id = v_household_id
+       AND user_id      = successor_user_id_in;
+
+    UPDATE public.household_members
+       SET role            = 'member',
+           pending_exit_at = now()
+     WHERE household_id = v_household_id
+       AND user_id      = v_user_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.handle_owner_leave(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.handle_owner_leave(uuid) TO authenticated;
+
+
+-- Backstop: hard-delete memberships whose grace period (30 days) has passed.
+-- Intended to be invoked by pg_cron; safe to run manually too.
+CREATE OR REPLACE FUNCTION public.sweep_pending_exits()
+RETURNS integer
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+    v_cnt integer;
+BEGIN
+    WITH deleted AS (
+        DELETE FROM public.household_members
+         WHERE pending_exit_at IS NOT NULL
+           AND pending_exit_at < now() - interval '30 days'
+         RETURNING household_id
+    ),
+    emptied AS (
+        SELECT household_id FROM deleted
+         WHERE NOT EXISTS (
+            SELECT 1 FROM public.household_members hm
+             WHERE hm.household_id = deleted.household_id
+         )
+    )
+    DELETE FROM public.households WHERE id IN (SELECT household_id FROM emptied);
+
+    GET DIAGNOSTICS v_cnt = ROW_COUNT;
+    RETURN v_cnt;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.sweep_pending_exits() FROM PUBLIC;
+-- Not granted to authenticated: invoked by service role / pg_cron only.

--- a/supabase/migrations/20260512110000_ensure_user_has_household_skip_pending.sql
+++ b/supabase/migrations/20260512110000_ensure_user_has_household_skip_pending.sql
@@ -1,0 +1,45 @@
+-- ensure_user_has_household: ignore pending-exit memberships when deciding
+-- whether the user needs a new personal household. Otherwise a soft-removed
+-- user with no other household would be looped back into the household
+-- they're being exited from.
+
+CREATE OR REPLACE FUNCTION public.ensure_user_has_household()
+RETURNS uuid
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+    v_user_id      uuid := auth.uid();
+    v_existing     uuid;
+    v_household_id uuid;
+    v_full_name    text;
+BEGIN
+    IF v_user_id IS NULL THEN
+        RAISE EXCEPTION 'not_authenticated';
+    END IF;
+
+    SELECT household_id INTO v_existing
+      FROM public.household_members
+     WHERE user_id        = v_user_id
+       AND pending_exit_at IS NULL
+     LIMIT 1;
+    IF v_existing IS NOT NULL THEN
+        RETURN v_existing;
+    END IF;
+
+    SELECT NULLIF(trim(full_name), '') INTO v_full_name
+      FROM public.profiles
+     WHERE id = v_user_id;
+
+    INSERT INTO public.households (name, currency, owner_id)
+    VALUES (COALESCE(v_full_name, 'My') || '''s Household', 'SEK', v_user_id)
+    RETURNING id INTO v_household_id;
+
+    INSERT INTO public.household_members (household_id, user_id, role)
+    VALUES (v_household_id, v_user_id, 'owner');
+
+    RETURN v_household_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.ensure_user_has_household() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.ensure_user_has_household() TO authenticated;

--- a/supabase/migrations/20260512120000_household_members_realtime.sql
+++ b/supabase/migrations/20260512120000_household_members_realtime.sql
@@ -1,0 +1,4 @@
+-- Enable Supabase realtime on household_members so the client can react
+-- live when an owner soft-removes a member (sets pending_exit_at).
+
+ALTER PUBLICATION supabase_realtime ADD TABLE public.household_members;

--- a/supabase/templates/confirmation.html
+++ b/supabase/templates/confirmation.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Confirm your email · Household Harmony</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #1F1D1B; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; color: #F1EDE5;">
+  <table cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #1F1D1B;">
+    <tr>
+      <td align="center" style="padding: 40px 16px;">
+        <table cellpadding="0" cellspacing="0" border="0" width="560" style="max-width: 100%; background-color: #2A2724; border: 1px solid #3A3631; border-radius: 16px; overflow: hidden;">
+          <tr>
+            <td align="center" style="padding: 36px 32px 8px;">
+              <img src="https://household-harmony.vercel.app/household-harmony-logo.svg" alt="" width="40" height="40" style="display: inline-block; vertical-align: middle; border: 0;">
+              <span style="display: inline-block; vertical-align: middle; margin-left: 10px; font-size: 19px; font-weight: 700; color: #F1EDE5; letter-spacing: -0.2px;">Household Harmony</span>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 24px 36px 32px; color: #F1EDE5;">
+              <h1 style="margin: 0 0 16px; font-size: 22px; font-weight: 600; color: #F1EDE5; letter-spacing: -0.3px;">
+                Welcome — confirm your email
+              </h1>
+              <p style="margin: 0 0 28px; font-size: 15px; line-height: 1.6; color: #C2BDB4;">
+                You're almost in. Click below to verify your email and unlock your account.
+              </p>
+              <table cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td align="center" style="padding: 0 0 28px;">
+                    <a href="{{ .ConfirmationURL }}" style="display: inline-block; padding: 14px 32px; background-color: #54C470; color: #0E1A12; text-decoration: none; border-radius: 12px; font-weight: 600; font-size: 15px;">
+                      Confirm email
+                    </a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin: 0 0 6px; font-size: 13px; color: #8B857B;">
+                Or paste this link into your browser:
+              </p>
+              <p style="margin: 0; word-break: break-all;">
+                <a href="{{ .ConfirmationURL }}" style="color: #54C470; text-decoration: none; font-size: 13px;">{{ .ConfirmationURL }}</a>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 20px 36px; border-top: 1px solid #3A3631; background-color: rgba(0,0,0,0.15);">
+              <p style="margin: 0 0 6px; font-size: 12px; color: #8B857B; text-align: center;">
+                This link expires in 24 hours.
+              </p>
+              <p style="margin: 0; font-size: 12px; color: #8B857B; text-align: center;">
+                Didn't sign up? Ignore this email — nothing happens.
+              </p>
+            </td>
+          </tr>
+        </table>
+        <p style="margin: 16px 0 0; font-size: 12px; color: #8B857B; text-align: center;">
+          © 2026 Household Harmony
+        </p>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/supabase/templates/email_change.html
+++ b/supabase/templates/email_change.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Confirm your new email · Household Harmony</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #1F1D1B; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; color: #F1EDE5;">
+  <table cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #1F1D1B;">
+    <tr>
+      <td align="center" style="padding: 40px 16px;">
+        <table cellpadding="0" cellspacing="0" border="0" width="560" style="max-width: 100%; background-color: #2A2724; border: 1px solid #3A3631; border-radius: 16px; overflow: hidden;">
+          <tr>
+            <td align="center" style="padding: 36px 32px 8px;">
+              <img src="https://household-harmony.vercel.app/household-harmony-logo.svg" alt="" width="40" height="40" style="display: inline-block; vertical-align: middle; border: 0;">
+              <span style="display: inline-block; vertical-align: middle; margin-left: 10px; font-size: 19px; font-weight: 700; color: #F1EDE5; letter-spacing: -0.2px;">Household Harmony</span>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 24px 36px 32px; color: #F1EDE5;">
+              <h1 style="margin: 0 0 16px; font-size: 22px; font-weight: 600; color: #F1EDE5; letter-spacing: -0.3px;">
+                Confirm your new email
+              </h1>
+              <p style="margin: 0 0 24px; font-size: 15px; line-height: 1.6; color: #C2BDB4;">
+                We received a request to change your address from <strong style="color: #F1EDE5;">{{ .Email }}</strong> to <strong style="color: #54C470;">{{ .NewEmail }}</strong>. Confirm below to complete the switch.
+              </p>
+              <table cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td align="center" style="padding: 0 0 28px;">
+                    <a href="{{ .ConfirmationURL }}" style="display: inline-block; padding: 14px 32px; background-color: #54C470; color: #0E1A12; text-decoration: none; border-radius: 12px; font-weight: 600; font-size: 15px;">
+                      Confirm new email
+                    </a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin: 0 0 6px; font-size: 13px; color: #8B857B;">
+                Or paste this link into your browser:
+              </p>
+              <p style="margin: 0 0 24px; word-break: break-all;">
+                <a href="{{ .ConfirmationURL }}" style="color: #54C470; text-decoration: none; font-size: 13px;">{{ .ConfirmationURL }}</a>
+              </p>
+              <table cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td style="padding: 14px 16px; background-color: rgba(224, 133, 102, 0.10); border-left: 3px solid #E08566; border-radius: 8px;">
+                    <p style="margin: 0; font-size: 13px; line-height: 1.5; color: #E8B8A4;">
+                      Didn't request this change? Your current email stays active until you confirm.
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 20px 36px; border-top: 1px solid #3A3631; background-color: rgba(0,0,0,0.15);">
+              <p style="margin: 0; font-size: 12px; color: #8B857B; text-align: center;">
+                This link expires in 24 hours.
+              </p>
+            </td>
+          </tr>
+        </table>
+        <p style="margin: 16px 0 0; font-size: 12px; color: #8B857B; text-align: center;">
+          © 2026 Household Harmony
+        </p>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/supabase/templates/invite.html
+++ b/supabase/templates/invite.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>You've been invited · Household Harmony</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #1F1D1B; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; color: #F1EDE5;">
+  <table cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #1F1D1B;">
+    <tr>
+      <td align="center" style="padding: 40px 16px;">
+        <table cellpadding="0" cellspacing="0" border="0" width="560" style="max-width: 100%; background-color: #2A2724; border: 1px solid #3A3631; border-radius: 16px; overflow: hidden;">
+          <tr>
+            <td align="center" style="padding: 36px 32px 8px;">
+              <img src="https://household-harmony.vercel.app/household-harmony-logo.svg" alt="" width="40" height="40" style="display: inline-block; vertical-align: middle; border: 0;">
+              <span style="display: inline-block; vertical-align: middle; margin-left: 10px; font-size: 19px; font-weight: 700; color: #F1EDE5; letter-spacing: -0.2px;">Household Harmony</span>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 24px 36px 32px; color: #F1EDE5;">
+              <h1 style="margin: 0 0 16px; font-size: 22px; font-weight: 600; color: #F1EDE5; letter-spacing: -0.3px;">
+                You've been invited to a household
+              </h1>
+              <p style="margin: 0 0 28px; font-size: 15px; line-height: 1.6; color: #C2BDB4;">
+                Someone you know wants to share their household finances with you. Accept to create your account and start tracking income, expenses and budgets together.
+              </p>
+              <table cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td align="center" style="padding: 0 0 28px;">
+                    <a href="{{ .ConfirmationURL }}" style="display: inline-block; padding: 14px 32px; background-color: #54C470; color: #0E1A12; text-decoration: none; border-radius: 12px; font-weight: 600; font-size: 15px;">
+                      Accept invite
+                    </a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin: 0 0 6px; font-size: 13px; color: #8B857B;">
+                Or paste this link into your browser:
+              </p>
+              <p style="margin: 0; word-break: break-all;">
+                <a href="{{ .ConfirmationURL }}" style="color: #54C470; text-decoration: none; font-size: 13px;">{{ .ConfirmationURL }}</a>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 20px 36px; border-top: 1px solid #3A3631; background-color: rgba(0,0,0,0.15);">
+              <p style="margin: 0 0 6px; font-size: 12px; color: #8B857B; text-align: center;">
+                This invite expires in 7 days.
+              </p>
+              <p style="margin: 0; font-size: 12px; color: #8B857B; text-align: center;">
+                Weren't expecting this? You can safely ignore it.
+              </p>
+            </td>
+          </tr>
+        </table>
+        <p style="margin: 16px 0 0; font-size: 12px; color: #8B857B; text-align: center;">
+          © 2026 Household Harmony
+        </p>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/supabase/templates/magic_link.html
+++ b/supabase/templates/magic_link.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Your login link · Household Harmony</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #1F1D1B; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; color: #F1EDE5;">
+  <table cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #1F1D1B;">
+    <tr>
+      <td align="center" style="padding: 40px 16px;">
+        <table cellpadding="0" cellspacing="0" border="0" width="560" style="max-width: 100%; background-color: #2A2724; border: 1px solid #3A3631; border-radius: 16px; overflow: hidden;">
+          <tr>
+            <td align="center" style="padding: 36px 32px 8px;">
+              <img src="https://household-harmony.vercel.app/household-harmony-logo.svg" alt="" width="40" height="40" style="display: inline-block; vertical-align: middle; border: 0;">
+              <span style="display: inline-block; vertical-align: middle; margin-left: 10px; font-size: 19px; font-weight: 700; color: #F1EDE5; letter-spacing: -0.2px;">Household Harmony</span>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 24px 36px 32px; color: #F1EDE5;">
+              <h1 style="margin: 0 0 16px; font-size: 22px; font-weight: 600; color: #F1EDE5; letter-spacing: -0.3px;">
+                Your one-click login
+              </h1>
+              <p style="margin: 0 0 28px; font-size: 15px; line-height: 1.6; color: #C2BDB4;">
+                Tap below to sign in. No password needed.
+              </p>
+              <table cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td align="center" style="padding: 0 0 28px;">
+                    <a href="{{ .ConfirmationURL }}" style="display: inline-block; padding: 14px 32px; background-color: #54C470; color: #0E1A12; text-decoration: none; border-radius: 12px; font-weight: 600; font-size: 15px;">
+                      Log in
+                    </a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin: 0 0 6px; font-size: 13px; color: #8B857B;">
+                Or paste this link into your browser:
+              </p>
+              <p style="margin: 0 0 24px; word-break: break-all;">
+                <a href="{{ .ConfirmationURL }}" style="color: #54C470; text-decoration: none; font-size: 13px;">{{ .ConfirmationURL }}</a>
+              </p>
+              <table cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td style="padding: 14px 16px; background-color: rgba(224, 133, 102, 0.10); border-left: 3px solid #E08566; border-radius: 8px;">
+                    <p style="margin: 0; font-size: 13px; line-height: 1.5; color: #E8B8A4;">
+                      Didn't request this? Ignore the email — someone may have typed your address by mistake.
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 20px 36px; border-top: 1px solid #3A3631; background-color: rgba(0,0,0,0.15);">
+              <p style="margin: 0 0 6px; font-size: 12px; color: #8B857B; text-align: center;">
+                This link expires in 15 minutes and can only be used once.
+              </p>
+            </td>
+          </tr>
+        </table>
+        <p style="margin: 16px 0 0; font-size: 12px; color: #8B857B; text-align: center;">
+          © 2026 Household Harmony
+        </p>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/supabase/templates/reauthentication.html
+++ b/supabase/templates/reauthentication.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Your verification code · Household Harmony</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #1F1D1B; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; color: #F1EDE5;">
+  <table cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #1F1D1B;">
+    <tr>
+      <td align="center" style="padding: 40px 16px;">
+        <table cellpadding="0" cellspacing="0" border="0" width="560" style="max-width: 100%; background-color: #2A2724; border: 1px solid #3A3631; border-radius: 16px; overflow: hidden;">
+          <tr>
+            <td align="center" style="padding: 36px 32px 8px;">
+              <img src="https://household-harmony.vercel.app/household-harmony-logo.svg" alt="" width="40" height="40" style="display: inline-block; vertical-align: middle; border: 0;">
+              <span style="display: inline-block; vertical-align: middle; margin-left: 10px; font-size: 19px; font-weight: 700; color: #F1EDE5; letter-spacing: -0.2px;">Household Harmony</span>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 24px 36px 32px; color: #F1EDE5;">
+              <h1 style="margin: 0 0 16px; font-size: 22px; font-weight: 600; color: #F1EDE5; letter-spacing: -0.3px;">
+                Your verification code
+              </h1>
+              <p style="margin: 0 0 24px; font-size: 15px; line-height: 1.6; color: #C2BDB4;">
+                Enter this code in the app to confirm it's you:
+              </p>
+              <table cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td align="center" style="padding: 0 0 28px;">
+                    <div style="display: inline-block; padding: 22px 36px; background-color: #1F1D1B; border: 2px solid #54C470; border-radius: 12px;">
+                      <span style="font-family: 'SF Mono', Menlo, Consolas, 'Courier New', monospace; font-size: 32px; font-weight: 700; letter-spacing: 8px; color: #54C470;">{{ .Token }}</span>
+                    </div>
+                  </td>
+                </tr>
+              </table>
+              <table cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td style="padding: 14px 16px; background-color: rgba(224, 133, 102, 0.10); border-left: 3px solid #E08566; border-radius: 8px;">
+                    <p style="margin: 0; font-size: 13px; line-height: 1.5; color: #E8B8A4;">
+                      Never share this code. We will never ask you for it.
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 20px 36px; border-top: 1px solid #3A3631; background-color: rgba(0,0,0,0.15);">
+              <p style="margin: 0; font-size: 12px; color: #8B857B; text-align: center;">
+                This code expires in 10 minutes.
+              </p>
+            </td>
+          </tr>
+        </table>
+        <p style="margin: 16px 0 0; font-size: 12px; color: #8B857B; text-align: center;">
+          © 2026 Household Harmony
+        </p>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/supabase/templates/recovery.html
+++ b/supabase/templates/recovery.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reset your password · Household Harmony</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #1F1D1B; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; color: #F1EDE5;">
+  <table cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #1F1D1B;">
+    <tr>
+      <td align="center" style="padding: 40px 16px;">
+        <table cellpadding="0" cellspacing="0" border="0" width="560" style="max-width: 100%; background-color: #2A2724; border: 1px solid #3A3631; border-radius: 16px; overflow: hidden;">
+          <tr>
+            <td align="center" style="padding: 36px 32px 8px;">
+              <img src="https://household-harmony.vercel.app/household-harmony-logo.svg" alt="" width="40" height="40" style="display: inline-block; vertical-align: middle; border: 0;">
+              <span style="display: inline-block; vertical-align: middle; margin-left: 10px; font-size: 19px; font-weight: 700; color: #F1EDE5; letter-spacing: -0.2px;">Household Harmony</span>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 24px 36px 32px; color: #F1EDE5;">
+              <h1 style="margin: 0 0 16px; font-size: 22px; font-weight: 600; color: #F1EDE5; letter-spacing: -0.3px;">
+                Reset your password
+              </h1>
+              <p style="margin: 0 0 28px; font-size: 15px; line-height: 1.6; color: #C2BDB4;">
+                Tap below to choose a new password for your account.
+              </p>
+              <table cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td align="center" style="padding: 0 0 28px;">
+                    <a href="{{ .ConfirmationURL }}" style="display: inline-block; padding: 14px 32px; background-color: #54C470; color: #0E1A12; text-decoration: none; border-radius: 12px; font-weight: 600; font-size: 15px;">
+                      Set a new password
+                    </a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin: 0 0 6px; font-size: 13px; color: #8B857B;">
+                Or paste this link into your browser:
+              </p>
+              <p style="margin: 0 0 24px; word-break: break-all;">
+                <a href="{{ .ConfirmationURL }}" style="color: #54C470; text-decoration: none; font-size: 13px;">{{ .ConfirmationURL }}</a>
+              </p>
+              <table cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td style="padding: 14px 16px; background-color: rgba(224, 133, 102, 0.10); border-left: 3px solid #E08566; border-radius: 8px;">
+                    <p style="margin: 0; font-size: 13px; line-height: 1.5; color: #E8B8A4;">
+                      Didn't ask for this? Ignore the email and your password stays the same.
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 20px 36px; border-top: 1px solid #3A3631; background-color: rgba(0,0,0,0.15);">
+              <p style="margin: 0; font-size: 12px; color: #8B857B; text-align: center;">
+                This link expires in 60 minutes.
+              </p>
+            </td>
+          </tr>
+        </table>
+        <p style="margin: 16px 0 0; font-size: 12px; color: #8B857B; text-align: center;">
+          © 2026 Household Harmony
+        </p>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **Household-shared encryption** — members can now decrypt each other's data via a per-household DEK; each member keeps their own password-wrapped copy. Invites carry an invite-code-wrapped copy so new members unwrap + re-wrap under their own password on join.
- **Soft-exit flow with item duplication** — removing a member (or self-leave) no longer hard-deletes their access. On their next login they get a dialog to pick which income/expense/subscription/insurance items to duplicate into their personal household; subjects auto-included. Realtime subscription means a live-logged-in user gets toasted + reloaded immediately. 30-day backstop function in place (not yet scheduled).
- **Join wizard rewrite** — state-machine driven dialog with `joining → settling → done`; no more half-authenticated render against incomplete contexts. Race fix in `HouseholdContext` (fetch-generation counter) so stale fetches can't clobber fresh ones.
- **Form + UI polish** — Insurance/Subscription dialogs now close after add (delegate-form pattern lost `createAnother` visibility); toast close-X always visible; money input treats 0 as empty so clearing doesn't fight back; settings-icon hover; Expenses page refreshes subjects after inline create; setup wizard list shows provider/service.

## Test plan

- [ ] Owner invites a member — invitee creates account, lands cleanly with full state, can see existing household data
- [ ] Owner removes a member while they're logged in — toast + auto-reload — next login shows the bring-items dialog with items pre-checked by authorship
- [ ] Dialog: pick items, confirm, items appear immediately in the personal household's Overview/Income/Expenses without manual refresh
- [ ] Recovery code still works (single-user)
- [ ] Setup wizard does NOT appear on top of the exit dialog
- [ ] Existing flows (add income/expense/sub/insurance) still close+reset correctly with and without "Create another"

🤖 Generated with [Claude Code](https://claude.com/claude-code)