### PR TITLE
Credit pipeline: one-time entries + actual-prominent display

### DIFF
--- a/frontend/src/components/expenses/AllTabBlockView.tsx
+++ b/frontend/src/components/expenses/AllTabBlockView.tsx
@@ -33,6 +33,9 @@ interface ExpenseItem {
     member?: { name: string };
     inactive?: boolean;
     isCredit?: boolean;
+    /** Suppress click + hover affordance. Used for historical one-time entries
+     *  that have no edit surface yet. */
+    readOnly?: boolean;
 }
 
 const SUBJECT_ICON: Record<string, any> = {
@@ -206,7 +209,7 @@ export const ExpenseBlock = ({
                             <RowItem
                                 key={item.id}
                                 last={isLast}
-                                onClick={() => onItemClick?.(item.id)}
+                                onClick={item.readOnly ? undefined : () => onItemClick?.(item.id)}
                                 className={`group ${item.inactive ? "opacity-50" : ""}`}
                             >
                                 <div className="flex items-center gap-3 min-w-0 flex-1">
@@ -240,6 +243,13 @@ export const ExpenseBlock = ({
                                             widthClassName="w-20 sm:w-24"
                                             onChange={(v) => onAmountChange(item.id, v.toString())}
                                         />
+                                    ) : item.actualAmount !== undefined ? (
+                                        <Money
+                                            v={item.actualAmount}
+                                            currency={currency}
+                                            size="base"
+                                            weight={500}
+                                        />
                                     ) : item.displayAmount !== undefined ? (
                                         <span className="flex items-baseline gap-1">
                                             <Money
@@ -262,21 +272,6 @@ export const ExpenseBlock = ({
                                             estimate={categoryType === 'expense' && isCategoryBudgeted(item.category)}
                                         />
                                     )}
-                                    {item.actualAmount !== undefined && Math.round(item.actualAmount) !== Math.round(item.amount) && (() => {
-                                        const variance = item.actualAmount - item.amount;
-                                        const over = variance > 0;
-                                        return (
-                                            <span
-                                                className={`text-[10px] font-semibold tracking-wide px-1.5 py-0.5 rounded ${over
-                                                    ? "bg-danger/10 text-danger"
-                                                    : "bg-accent/10 text-accent"
-                                                    }`}
-                                                title={`Actual: ${Math.round(item.actualAmount)} ${currency}`}
-                                            >
-                                                {over ? "+" : "−"}{Math.abs(Math.round(variance))} {currency}
-                                            </span>
-                                        );
-                                    })()}
                                     <Pencil className="h-3.5 w-3.5 text-muted hidden md:block md:opacity-0 md:group-hover:opacity-100 transition-opacity" />
                                 </div>
                             </RowItem>

--- a/frontend/src/components/expenses/credit/ParsedTransactionsReview.tsx
+++ b/frontend/src/components/expenses/credit/ParsedTransactionsReview.tsx
@@ -9,7 +9,7 @@ import { Check, Loader2, X } from "lucide-react";
 import { formatCurrency } from "@/utils/formatting";
 import { creditCategories } from "@/constants/creditCategories";
 import { supabase } from "@/integrations/supabase/client";
-import { useEncryptedFields, expenseFields, monthlyExpenseFields } from "@/hooks/useEncryptedFields";
+import { useEncryptedFields, monthlyExpenseFields } from "@/hooks/useEncryptedFields";
 
 export interface ParsedTransaction {
     date: string;
@@ -44,7 +44,6 @@ export const ParsedTransactionsReview = ({
     const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set(initialTransactions.map((_, i) => i)));
     const [saving, setSaving] = useState(false);
     const [selectedCardId, setSelectedCardId] = useState(creditCards[0]?.id || "");
-    const { encryptRecord: encryptExpense } = useEncryptedFields(expenseFields);
     const { encryptRecord: encryptMonthlyExpense } = useEncryptedFields(monthlyExpenseFields);
 
     const handleToggleSelect = (index: number) => {
@@ -109,50 +108,68 @@ export const ParsedTransactionsReview = ({
                     .eq("is_credit", true)
                     .maybeSingle();
 
-                let expenseId: string;
+                let upsertErr: { message?: string } | null = null;
 
                 if (existingExpense?.id) {
-                    expenseId = existingExpense.id;
-                } else {
-                    const expenseName = `Credit: ${category.charAt(0).toUpperCase() + category.slice(1).replace(/_/g, ' ')}`;
-                    const newExpenseData = {
+                    // Budgeted credit-paid source — write the month's actual.
+                    const monthlyData = {
                         household_id: householdId,
-                        category,
-                        name: expenseName,
-                        budget: 0,
+                        expense_id: existingExpense.id,
+                        month: monthStr,
+                        month_start: monthStartIso,
+                        month_end: monthEndIso,
+                        actual_amount: roundedAmount,
                         created_by: user.id,
-                        is_active: true,
-                        is_credit: true,
-                        sort_order: 999,
                     };
+                    const encryptedMonthly = await encryptMonthlyExpense(monthlyData);
+                    const { error } = await supabase
+                        .from("monthly_expenses")
+                        .upsert(encryptedMonthly, { onConflict: "expense_id,month" });
+                    upsertErr = error;
+                } else {
+                    // No budgeted source for this category — record as a one-time
+                    // entry on this month only. No source pollution; the row is
+                    // visible in the month it was charged and nowhere else.
+                    // Smart Defaults can later recommend promoting frequent
+                    // categories to budgeted items (#68).
+                    const categoryLabel = creditCategories.find(c => c.value === category)?.label
+                        || category.charAt(0).toUpperCase() + category.slice(1).replace(/_/g, " ");
 
-                    const encryptedExpense = await encryptExpense(newExpenseData);
-                    const { data: created, error: createError } = await supabase
-                        .from("expenses")
-                        .insert({ ...encryptedExpense, category })
+                    const { data: existingOneTime } = await supabase
+                        .from("monthly_expenses")
                         .select("id")
-                        .single();
+                        .eq("household_id", householdId)
+                        .eq("month", monthStr)
+                        .eq("one_time_category", category)
+                        .is("expense_id", null)
+                        .maybeSingle();
 
-                    if (createError || !created) {
-                        console.error("Failed to create expense:", createError);
-                        continue;
+                    const oneTimeData = {
+                        household_id: householdId,
+                        expense_id: null,
+                        month: monthStr,
+                        month_start: monthStartIso,
+                        month_end: monthEndIso,
+                        one_time_name: categoryLabel,
+                        one_time_category: category,
+                        actual_amount: roundedAmount,
+                        created_by: user.id,
+                    };
+                    const encryptedOneTime = await encryptMonthlyExpense(oneTimeData);
+
+                    if (existingOneTime?.id) {
+                        const { error } = await supabase
+                            .from("monthly_expenses")
+                            .update(encryptedOneTime)
+                            .eq("id", existingOneTime.id);
+                        upsertErr = error;
+                    } else {
+                        const { error } = await supabase
+                            .from("monthly_expenses")
+                            .insert(encryptedOneTime);
+                        upsertErr = error;
                     }
-                    expenseId = created.id;
                 }
-
-                const monthlyData = {
-                    household_id: householdId,
-                    expense_id: expenseId,
-                    month: monthStr,
-                    month_start: monthStartIso,
-                    month_end: monthEndIso,
-                    actual_amount: roundedAmount,
-                    created_by: user.id,
-                };
-                const encryptedMonthly = await encryptMonthlyExpense(monthlyData);
-                const { error: upsertErr } = await supabase
-                    .from("monthly_expenses")
-                    .upsert(encryptedMonthly, { onConflict: "expense_id,month" });
 
                 if (upsertErr) {
                     console.error("Failed to upsert monthly_expenses:", upsertErr);

--- a/frontend/src/pages/Expenses.tsx
+++ b/frontend/src/pages/Expenses.tsx
@@ -431,26 +431,45 @@ const Expenses = () => {
           </div>
 
           <AllTabBlockView
-            expenses={expenseCategories.map(cat => {
-              const monthly = monthlyExpenses.find((m: any) => m.expense_id === cat.id);
-              const rawActual = monthly?.actual_amount;
-              const actualAmount = rawActual !== undefined && rawActual !== null
-                ? Number(rawActual)
-                : undefined;
-              const subj = subjects.find(s => s.id === cat.subject_id);
-              const mem = members.find(m => m.id === cat.member_id);
-              return {
-                id: cat.id,
-                name: cat.name,
-                amount: parseFloat(cat.budget || '0'),
-                budget: parseFloat(cat.budget || '0'),
-                actualAmount,
-                category: cat.category,
-                subject: subj ? { name: subj.name, type: subj.type } : undefined,
-                member: mem ? { name: mem.profiles?.full_name ?? "Member" } : undefined,
-                isCredit: !!cat.is_credit,
-              };
-            }).sort((a, b) => (b.budget ?? 0) - (a.budget ?? 0))}
+            expenses={[
+              ...expenseCategories.map(cat => {
+                const monthly = monthlyExpenses.find((m: any) => m.expense_id === cat.id);
+                const rawActual = monthly?.actual_amount;
+                const actualAmount = rawActual !== undefined && rawActual !== null
+                  ? Number(rawActual)
+                  : undefined;
+                const subj = subjects.find(s => s.id === cat.subject_id);
+                const mem = members.find(m => m.id === cat.member_id);
+                return {
+                  id: cat.id,
+                  name: cat.name,
+                  amount: parseFloat(cat.budget || '0'),
+                  budget: parseFloat(cat.budget || '0'),
+                  actualAmount,
+                  category: cat.category,
+                  subject: subj ? { name: subj.name, type: subj.type } : undefined,
+                  member: mem ? { name: mem.profiles?.full_name ?? "Member" } : undefined,
+                  isCredit: !!cat.is_credit,
+                };
+              }),
+              // One-time entries (e.g. from credit-import for un-budgeted
+              // categories). Source-less rows live only in the month they were
+              // charged; rendered read-only here so the user sees the history.
+              ...monthlyExpenses
+                .filter((m: any) => m.expense_id == null && m.one_time_name)
+                .map((m: any) => {
+                  const actualAmount = m.actual_amount != null ? Number(m.actual_amount) : undefined;
+                  return {
+                    id: `onetime-${m.id}`,
+                    name: m.one_time_name as string,
+                    amount: actualAmount ?? 0,
+                    budget: undefined,
+                    actualAmount,
+                    category: m.one_time_category as string | undefined,
+                    readOnly: true,
+                  };
+                }),
+            ].sort((a, b) => (b.actualAmount ?? b.budget ?? 0) - (a.actualAmount ?? a.budget ?? 0))}
             subscriptions={[...subscriptions].sort((a, b) => parseFloat(String(b.amount)) - parseFloat(String(a.amount))).map(sub => {
               // Calculate if this subscription is due in current financial month
               let isDue = false;

--- a/supabase/migrations/20260519130000_credit_sources_to_one_time.sql
+++ b/supabase/migrations/20260519130000_credit_sources_to_one_time.sql
@@ -1,0 +1,41 @@
+-- Convert auto-created credit expense sources into one-time monthly entries.
+--
+-- Background: the credit-import pipeline used to create persistent `expenses`
+-- source rows for un-budgeted categories (budget=0, is_credit=true,
+-- sort_order=999). Those rows then appeared in every month's expense list,
+-- including months they had no actuals for. The pipeline now writes one-time
+-- `monthly_expenses` entries directly for that case; this migration backfills
+-- the existing data so the prior writes are no longer visible as zero-budget
+-- rows in the current month.
+--
+-- Discriminator: is_credit=true AND sort_order=999. The plaintext budget is
+-- encrypted, so we can't filter on it; sort_order is the pipeline's marker.
+-- Legitimate user-budgeted is_credit sources use the default sort_order.
+
+-- Step 1: convert monthly_expenses rows pointing to auto-created sources
+-- into one-time entries (expense_id=NULL, one_time_name set from category).
+UPDATE public.monthly_expenses me
+SET
+    expense_id = NULL,
+    one_time_name = CASE e.category::text
+        WHEN 'groceries'     THEN 'Groceries'
+        WHEN 'fuel'          THEN 'Fuel'
+        WHEN 'shopping'      THEN 'Shopping'
+        WHEN 'dining_out'    THEN 'Dining Out'
+        WHEN 'entertainment' THEN 'Entertainment'
+        WHEN 'car_repairs'   THEN 'Car Repairs'
+        WHEN 'travel'        THEN 'Travel'
+        WHEN 'healthcare'    THEN 'Healthcare'
+        WHEN 'other'         THEN 'Other'
+        ELSE INITCAP(REPLACE(e.category::text, '_', ' '))
+    END,
+    one_time_category = e.category::text
+FROM public.expenses e
+WHERE me.expense_id = e.id
+  AND e.is_credit = true
+  AND e.sort_order = 999;
+
+-- Step 2: delete the now-orphaned auto-created source rows.
+DELETE FROM public.expenses
+WHERE is_credit = true
+  AND sort_order = 999;


### PR DESCRIPTION
## Summary

- **Credit pipeline** ([#66](https://github.com/wahdanz1/household-harmony/issues/66)): un-budgeted categories now write **one-time \`monthly_expenses\` entries** (\`expense_id=NULL\`, \`one_time_name\`, \`one_time_category\`) instead of creating persistent \`budget=0\` source rows. The pipeline no longer pollutes the current-month Expenses list with categories the user hasn't budgeted for.
- **Expenses page** now renders one-time entries (read-only) for the viewed month, so the historical reconciliation is visible.
- **Display fix** ([#67](https://github.com/wahdanz1/household-harmony/issues/67)): when a row has an \`actualAmount\`, the actual is shown as the primary number (no more \"budget + variance pill\" misdirect). Variance pill removed entirely from row chrome — the user reading a past month sees the truth directly. Filed [#70](https://github.com/wahdanz1/household-harmony/issues/70) for a future Details dialog that gives variance / audit info a proper home.
- **Backfill migration** [\`20260519130000_credit_sources_to_one_time.sql\`](supabase/migrations/20260519130000_credit_sources_to_one_time.sql): converts the existing prod auto-created sources (3 rows × 6 monthly_expenses) to one-time entries, deletes the source rows. Discriminator is \`is_credit=true AND sort_order=999\` since the budget is encrypted server-side and not filterable directly.

## Test plan

- [ ] Apply the backfill migration (\`supabase db push\` after backup); confirm 3 expense sources removed, 6 monthly_expenses converted.
- [ ] Current-month Expenses page no longer shows the auto-created Credit rows.
- [ ] Past-month (April) Expenses page shows the converted one-time rows with their actuals as primary number, no variance pill, not clickable.
- [ ] Re-run a credit-import PDF for a month: budgeted categories (Mathandel/Bensin) reconcile correctly; un-budgeted categories create new one-time entries; re-importing updates the existing one-time entry rather than duplicating.

## Closes

- Closes #66 (structural pipeline fix landed; budget=0 invariant violation gone).
- Closes #67 (actual now shown prominently).

## Doesn't close

- [#68](https://github.com/wahdanz1/household-harmony/issues/68) (Smart Defaults) — separate feature, captured for later.
- [#70](https://github.com/wahdanz1/household-harmony/issues/70) (Details dialog) — filed today, future work.