### PR TITLE
One-off chip + cleanup orphan credit placeholders

### DIFF
--- a/frontend/src/components/expenses/AllTabBlockView.tsx
+++ b/frontend/src/components/expenses/AllTabBlockView.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { ChevronDown, ChevronRight, Pencil, AlertTriangle, Sparkles, Car, Baby, PawPrint, Box, Plus, CreditCard, User } from "lucide-react";
+import { ChevronDown, ChevronRight, Pencil, AlertTriangle, Sparkles, Car, Baby, PawPrint, Box, Plus, CreditCard, User, Zap } from "lucide-react";
 import { CatIcon } from "@/components/ui/cat-icon";
 import { ServiceIcon } from "@/components/ui/service-icon";
 import { Money } from "@/components/ui/money";
@@ -33,6 +33,9 @@ interface ExpenseItem {
     member?: { name: string };
     inactive?: boolean;
     isCredit?: boolean;
+    /** One-time entry (no expense source) — e.g. an un-budgeted category
+     *  recorded during credit-import. Drives the `[One-off]` chip. */
+    isOneOff?: boolean;
     /** Suppress click + hover affordance. Used for historical one-time entries
      *  that have no edit surface yet. */
     readOnly?: boolean;
@@ -66,6 +69,13 @@ const CreditChip = () => (
     <span className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded bg-surface-2 text-muted">
         <CreditCard className="h-3 w-3" />
         Credit
+    </span>
+);
+
+const OneOffChip = () => (
+    <span className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded bg-surface-2 text-muted">
+        <Zap className="h-3 w-3" />
+        One-off
     </span>
 );
 
@@ -231,6 +241,7 @@ export const ExpenseBlock = ({
                                         {item.subject && <SubjectChip subject={item.subject} />}
                                         {item.member && <MemberChip member={item.member} />}
                                         {item.isCredit && <CreditChip />}
+                                        {item.isOneOff && <OneOffChip />}
                                     </div>
                                 </div>
                                 <div className="flex items-center gap-2 shrink-0" onClick={(e) => e.stopPropagation()}>

--- a/frontend/src/pages/Expenses.tsx
+++ b/frontend/src/pages/Expenses.tsx
@@ -466,6 +466,7 @@ const Expenses = () => {
                     budget: undefined,
                     actualAmount,
                     category: m.one_time_category as string | undefined,
+                    isOneOff: true,
                     readOnly: true,
                   };
                 }),

--- a/supabase/migrations/20260521100000_cleanup_orphan_credit_placeholders.sql
+++ b/supabase/migrations/20260521100000_cleanup_orphan_credit_placeholders.sql
@@ -1,0 +1,29 @@
+-- Cleanup orphan one-time entries left by the credit-sources backfill.
+--
+-- Context: 20260519130000_credit_sources_to_one_time.sql converted every
+-- monthly_expenses row that pointed to an auto-created is_credit
+-- (sort_order=999, budget=0) source into a one-time entry. Some of those
+-- monthly_expenses rows were empty carry-forward placeholders created by
+-- the Expenses page when navigating to the current month: they had
+-- expense_id set but no actual_amount and no real data. After the backfill
+-- they became "one-time entries with no amount" — visible in the current
+-- month with no UX to remove them.
+--
+-- Discriminating criterion: a row that has no actual_amount, no notes, AND
+-- whose one_time_name is literally a credit-category label (the migration's
+-- own output). User-created one-offs via TemporaryExpenseFormDialog have
+-- free-text descriptions and an amount the user typed in, so they won't
+-- match all four conditions simultaneously.
+
+DELETE FROM public.monthly_expenses
+WHERE expense_id IS NULL
+  AND encrypted_actual_amount IS NULL
+  AND notes IS NULL
+  AND one_time_category IN (
+    'groceries', 'fuel', 'shopping', 'dining_out',
+    'entertainment', 'car_repairs', 'travel', 'healthcare', 'other'
+  )
+  AND one_time_name IN (
+    'Groceries', 'Fuel', 'Shopping', 'Dining Out',
+    'Entertainment', 'Car Repairs', 'Travel', 'Healthcare', 'Other'
+  );


### PR DESCRIPTION
## Summary

- **Cleanup migration** [\`20260521100000_cleanup_orphan_credit_placeholders.sql\`](supabase/migrations/20260521100000_cleanup_orphan_credit_placeholders.sql) — removes the 3 empty one-time entries that the [previous backfill](supabase/migrations/20260519130000_credit_sources_to_one_time.sql) accidentally created when it converted carry-forward placeholder rows along with the real reconciled ones. Filter is specific enough to leave manually-created one-offs untouched.
- **\`[One-off]\` chip** on rows where \`expense_id IS NULL && one_time_name IS NOT NULL\` — closes the visual gap where one-time entries (e.g. credit-import categorizations without a budget source) looked identical to source-tied entries. Uses Zap icon to match the existing \"One-off\" button affordance.

## Test plan

- [ ] Apply the cleanup migration; current-month Expenses page no longer shows Dining Out / Shopping / Healthcare phantoms.
- [ ] April (past month) view: Shopping, Dining Out, Healthcare rows show a \`[One-off]\` chip next to their name; Mathandel and Bensin keep their existing \`[Credit]\` chip; budgeted source-tied rows (Uddevallahem, Kiki's alimony, A-Kassa) have no chips. Same for any one-off in future months.

## Filed for later

- [#70](https://github.com/wahdanz1/household-harmony/issues/70) — Details dialog on past-month row click, including a \"Remove this entry\" action so users can delete unwanted one-time entries without needing a migration.