### PR TITLE
Exit/bring-along fixes + subject collision flow

### DIFF
--- a/frontend/src/components/auth/MultiHouseholdExitDialog.tsx
+++ b/frontend/src/components/auth/MultiHouseholdExitDialog.tsx
@@ -5,11 +5,14 @@ import {
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { RowItem } from "@/components/ui/row-item";
 import { CatIcon } from "@/components/ui/cat-icon";
 import { ServiceIcon } from "@/components/ui/service-icon";
 import { Money } from "@/components/ui/money";
-import { Loader2, ArrowRight, HandCoins, Home, Repeat, Shield, Sparkles } from "lucide-react";
+import { Loader2, ArrowRight, HandCoins, Home, Repeat, Shield, Sparkles, Car, Baby, PawPrint, Box } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
 import { useEncryption } from "@/contexts/EncryptionContext";
@@ -89,6 +92,29 @@ const SECTIONS: SectionConfig[] = [
 
 type ItemKind = "attributed" | "added";
 
+type CollisionResolutionKind = "merge" | "new";
+
+interface SubjectCollision {
+    oldSubjectId: string;
+    oldName: string;
+    type: string;
+    existingId: string;
+    existingName: string;
+}
+
+interface CollisionResolution {
+    kind: CollisionResolutionKind;
+    /** Used only when kind === "new". Empty falls back to "{oldName} (2)". */
+    newName: string;
+}
+
+const SUBJECT_TYPE_ICON: Record<string, any> = {
+    car: Car,
+    kid: Baby,
+    pet: PawPrint,
+    other: Box,
+};
+
 interface FetchedItem {
     id: string;
     raw: Record<string, any>;
@@ -143,6 +169,11 @@ export const MultiHouseholdExitDialog = () => {
     const [items, setItems] = useState<FetchedItem[]>([]);
     const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
     const [householdName, setHouseholdName] = useState<string | null>(null);
+    const [collisions, setCollisions] = useState<SubjectCollision[]>([]);
+    const [resolutions, setResolutions] = useState<Record<string, CollisionResolution>>({});
+    const [collisionDialogOpen, setCollisionDialogOpen] = useState(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const [pendingBringSubjects, setPendingBringSubjects] = useState<any[] | null>(null);
 
     const open = !!pendingExitHouseholdId && isUnlocked;
 
@@ -281,26 +312,118 @@ export const MultiHouseholdExitDialog = () => {
                 }
             }
 
-            const subjectIdMap = new Map<string, string>();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            let oldSubjects: any[] = [];
             if (subjectIdsToInclude.size > 0) {
-                const { data: oldSubjects } = await supabase
+                const { data } = await supabase
                     .from("subjects")
                     .select("*")
                     .in("id", Array.from(subjectIdsToInclude));
-                for (const sub of oldSubjects ?? []) {
-                    const { data: inserted } = await supabase
-                        .from("subjects")
-                        .insert({
-                            household_id: activeHousehold.id,
-                            type: sub.type as any,
-                            name: sub.name,
-                            user_id: sub.user_id === user.id ? user.id : null,
-                            sort_order: sub.sort_order ?? 0,
-                        })
-                        .select("id")
-                        .single();
-                    if (inserted) subjectIdMap.set(sub.id, inserted.id);
+                oldSubjects = data ?? [];
+            }
+
+            // Collision detection: a subject of the same type + name (case-
+            // insensitive, trimmed) already in the destination means the user
+            // needs to tell us if it's the same thing or just shares a name.
+            const detected: SubjectCollision[] = [];
+            if (oldSubjects.length > 0) {
+                const { data: destSubjects } = await supabase
+                    .from("subjects")
+                    .select("id, name, type")
+                    .eq("household_id", activeHousehold.id);
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const dest = (destSubjects ?? []) as any[];
+                for (const old of oldSubjects) {
+                    const oldNorm = (old.name ?? "").trim().toLowerCase();
+                    if (!oldNorm) continue;
+                    const existing = dest.find(s =>
+                        s.type === old.type && (s.name ?? "").trim().toLowerCase() === oldNorm
+                    );
+                    if (existing) {
+                        detected.push({
+                            oldSubjectId: old.id,
+                            oldName: old.name,
+                            type: old.type,
+                            existingId: existing.id,
+                            existingName: existing.name,
+                        });
+                    }
                 }
+            }
+
+            if (detected.length > 0) {
+                const defaults: Record<string, CollisionResolution> = {};
+                for (const c of detected) {
+                    defaults[c.oldSubjectId] = { kind: "merge", newName: `${c.oldName} (2)` };
+                }
+                setCollisions(detected);
+                setResolutions(defaults);
+                setPendingBringSubjects(oldSubjects);
+                setCollisionDialogOpen(true);
+                setSubmitting(false);
+                return;
+            }
+
+            await proceedWithBring(oldSubjects, {}, []);
+        } catch (err: any) {
+            console.error("Exit dialog failed:", err);
+            toast({
+                title: "Couldn't finish",
+                description: err?.message ?? "Try again.",
+                variant: "destructive",
+            });
+            setSubmitting(false);
+        }
+    };
+
+    const handleResolveCollisions = async () => {
+        if (!pendingBringSubjects) return;
+        const oldSubjects = pendingBringSubjects;
+        const detected = collisions;
+        const res = resolutions;
+        setCollisionDialogOpen(false);
+        setPendingBringSubjects(null);
+        setCollisions([]);
+        setResolutions({});
+        await proceedWithBring(oldSubjects, res, detected);
+    };
+
+    const proceedWithBring = async (
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        oldSubjects: any[],
+        res: Record<string, CollisionResolution>,
+        detectedCollisions: SubjectCollision[],
+    ) => {
+        if (!user || !activeHousehold?.id || !pendingExitHouseholdId) return;
+        setSubmitting(true);
+
+        try {
+            const subjectIdMap = new Map<string, string>();
+            const collisionLookup = new Map(detectedCollisions.map(c => [c.oldSubjectId, c]));
+            for (const old of oldSubjects) {
+                const r = res[old.id];
+                const collision = collisionLookup.get(old.id);
+                if (collision && r?.kind === "merge") {
+                    subjectIdMap.set(old.id, collision.existingId);
+                    continue;
+                }
+                const insertName = r?.kind === "new" && r.newName.trim()
+                    ? r.newName.trim()
+                    : collision
+                        ? `${old.name} (2)`
+                        : old.name;
+                const { data: inserted } = await supabase
+                    .from("subjects")
+                    .insert({
+                        household_id: activeHousehold.id,
+                        type: old.type as any,
+                        name: insertName,
+                        user_id: old.user_id === user.id ? user.id : null,
+                        sort_order: old.sort_order ?? 0,
+                    })
+                    .select("id")
+                    .single();
+                if (inserted) subjectIdMap.set(old.id, inserted.id);
             }
 
             // Seed monthly_* rows for the current financial month so Overview
@@ -429,6 +552,7 @@ export const MultiHouseholdExitDialog = () => {
     };
 
     return (
+        <>
         <Dialog open={open} onOpenChange={() => { /* not dismissable */ }}>
             <DialogContent
                 className="sm:max-w-2xl max-h-[90vh] overflow-y-auto"
@@ -533,7 +657,7 @@ export const MultiHouseholdExitDialog = () => {
                             {selectedIds.size === items.length ? "Clear all" : "Select all"}
                         </button>
                     ) : <span />}
-                    <Button onClick={handleConfirm} disabled={submitting || loading}>
+                    <Button onClick={handleConfirm} disabled={submitting || loading || collisionDialogOpen}>
                         {submitting ? (
                             <><Loader2 className="h-4 w-4 mr-2 animate-spin" />Bringing…</>
                         ) : items.length === 0 ? (
@@ -545,5 +669,77 @@ export const MultiHouseholdExitDialog = () => {
                 </DialogFooter>
             </DialogContent>
         </Dialog>
+
+        <Dialog open={collisionDialogOpen} onOpenChange={() => { /* not dismissable */ }}>
+            <DialogContent
+                className="sm:max-w-md"
+                hideClose
+                onPointerDownOutside={(e) => e.preventDefault()}
+                onEscapeKeyDown={(e) => e.preventDefault()}
+            >
+                <DialogHeader>
+                    <DialogTitle>Resolve duplicate labels</DialogTitle>
+                    <DialogDescription>
+                        Some of the labels you're bringing along already exist here. Tell us which is which.
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-3">
+                    {collisions.map(c => {
+                        const r = resolutions[c.oldSubjectId] ?? { kind: "merge", newName: `${c.oldName} (2)` };
+                        const TypeIcon = SUBJECT_TYPE_ICON[c.type] ?? Box;
+                        return (
+                            <div key={c.oldSubjectId} className="space-y-2 rounded-lg border border-line p-3">
+                                <div className="flex items-center gap-2">
+                                    <TypeIcon className="h-4 w-4 text-muted" />
+                                    <span className="font-medium">{c.oldName}</span>
+                                    <span className="text-xs text-muted">already exists</span>
+                                </div>
+                                <RadioGroup
+                                    value={r.kind}
+                                    onValueChange={(v) => setResolutions(prev => ({
+                                        ...prev,
+                                        [c.oldSubjectId]: {
+                                            kind: v as CollisionResolutionKind,
+                                            newName: prev[c.oldSubjectId]?.newName ?? `${c.oldName} (2)`,
+                                        },
+                                    }))}
+                                    className="space-y-1.5"
+                                >
+                                    <div className="flex items-center gap-2">
+                                        <RadioGroupItem value="merge" id={`r-merge-${c.oldSubjectId}`} />
+                                        <Label htmlFor={`r-merge-${c.oldSubjectId}`} className="text-sm font-normal cursor-pointer">
+                                            Same as the existing "{c.existingName}"
+                                        </Label>
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                        <RadioGroupItem value="new" id={`r-new-${c.oldSubjectId}`} />
+                                        <Label htmlFor={`r-new-${c.oldSubjectId}`} className="text-sm font-normal cursor-pointer">
+                                            Different — keep mine separately
+                                        </Label>
+                                    </div>
+                                </RadioGroup>
+                                {r.kind === "new" && (
+                                    <Input
+                                        value={r.newName}
+                                        onChange={(e) => setResolutions(prev => ({
+                                            ...prev,
+                                            [c.oldSubjectId]: { kind: "new", newName: e.target.value },
+                                        }))}
+                                        placeholder={`${c.oldName} (2)`}
+                                        className="text-sm"
+                                    />
+                                )}
+                            </div>
+                        );
+                    })}
+                </div>
+                <DialogFooter>
+                    <Button onClick={handleResolveCollisions} disabled={submitting}>
+                        Continue <ArrowRight className="h-4 w-4 ml-2" />
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+        </>
     );
 };

--- a/frontend/src/components/auth/MultiHouseholdExitDialog.tsx
+++ b/frontend/src/components/auth/MultiHouseholdExitDialog.tsx
@@ -356,8 +356,13 @@ export const MultiHouseholdExitDialog = () => {
                         newRow[section.coParentCol] = null;
                     }
                     if ("member_id" in newRow) {
-                        const newMembershipId = activeMembers.find(m => m.user_id === user.id)?.id ?? null;
-                        newRow.member_id = newMembershipId;
+                        // The *_one_attribution check constraint allows member_id
+                        // OR subject_id, never both. Default to the current user's
+                        // new membership only when the row isn't subject-attributed.
+                        const hasSubject = !!(section.subjectCol && newRow[section.subjectCol]);
+                        newRow.member_id = hasSubject
+                            ? null
+                            : activeMembers.find(m => m.user_id === user.id)?.id ?? null;
                     }
 
                     const { data: insertedSource, error: insertError } = await (supabase as any)

--- a/frontend/src/components/expenses/SubscriptionFormDialog.tsx
+++ b/frontend/src/components/expenses/SubscriptionFormDialog.tsx
@@ -11,7 +11,7 @@ interface SubscriptionFormDialogProps {
         id?: string;
         name?: string;
         service?: string;
-        amount?: number | string;
+        budget?: number | string;
         billing_cycle?: string;
         category?: string;
         notes?: string;

--- a/frontend/src/components/settings/HouseholdCard.tsx
+++ b/frontend/src/components/settings/HouseholdCard.tsx
@@ -85,7 +85,10 @@ export const HouseholdCard = ({ household, members, userRole, onUpdate }: Househ
 
         toast.success("Leaving household — reloading…");
         setLeaveOpen(false);
-        setTimeout(() => window.location.reload(), 1000);
+        // Full navigation (not reload) so the user lands on Overview, not back
+        // on Settings where they triggered the leave. The bring-along dialog
+        // will pop up over Overview after the bootstrap settles.
+        setTimeout(() => { window.location.href = "/"; }, 1000);
     };
 
     return (

--- a/frontend/src/components/settings/dialogs/ManageSubjectsDialog.tsx
+++ b/frontend/src/components/settings/dialogs/ManageSubjectsDialog.tsx
@@ -37,6 +37,7 @@ interface ManageSubjectsDialogProps {
 
 export const ManageSubjectsDialog = ({ open, onOpenChange, type, label, householdId, onChange }: ManageSubjectsDialogProps) => {
     const [subjects, setSubjects] = useState<Subject[]>([]);
+    const [counts, setCounts] = useState<Record<string, number>>({});
     const [editingId, setEditingId] = useState<string | null>(null);
     const [draftName, setDraftName] = useState("");
     const [adding, setAdding] = useState(false);
@@ -50,7 +51,31 @@ export const ManageSubjectsDialog = ({ open, onOpenChange, type, label, househol
             .eq("type", type)
             .order("sort_order")
             .order("name");
-        setSubjects((data as Subject[]) ?? []);
+        const fetched = (data as Subject[]) ?? [];
+        setSubjects(fetched);
+
+        if (fetched.length === 0) {
+            setCounts({});
+            return;
+        }
+
+        // Count live (non-archived) items attached to each subject. Spans the
+        // three tables that have subject_id: expenses, subscriptions,
+        // insurances. income_sources has no subject_id, so it doesn't count.
+        const subjectIds = fetched.map(s => s.id);
+        const [expRows, subRows, insRows] = await Promise.all([
+            supabase.from("expenses").select("subject_id").eq("household_id", householdId).in("subject_id", subjectIds).is("archived_at", null),
+            supabase.from("subscriptions").select("subject_id").eq("household_id", householdId).in("subject_id", subjectIds).is("archived_at", null),
+            supabase.from("insurances").select("subject_id").eq("household_id", householdId).in("subject_id", subjectIds).is("archived_at", null),
+        ]);
+        const next: Record<string, number> = {};
+        for (const sid of subjectIds) next[sid] = 0;
+        for (const row of [...(expRows.data ?? []), ...(subRows.data ?? []), ...(insRows.data ?? [])]) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const sid = (row as any).subject_id as string | null;
+            if (sid && sid in next) next[sid] += 1;
+        }
+        setCounts(next);
     };
 
     useEffect(() => {
@@ -143,6 +168,9 @@ export const ManageSubjectsDialog = ({ open, onOpenChange, type, label, househol
                             ) : (
                                 <>
                                     <span className="flex-1 text-sm text-ink">{s.name}</span>
+                                    <span className="text-xs text-muted tabular-nums">
+                                        {(counts[s.id] ?? 0)} connection{(counts[s.id] ?? 0) === 1 ? "" : "s"}
+                                    </span>
                                     <Button
                                         size="icon"
                                         variant="ghost"

--- a/frontend/src/components/ui/checkbox.tsx
+++ b/frontend/src/components/ui/checkbox.tsx
@@ -11,7 +11,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-accent ring-offset-bg data-[state=checked]:bg-accent data-[state=checked]:text-accent-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      "peer h-5 w-5 shrink-0 rounded-sm border border-accent ring-offset-bg data-[state=checked]:bg-accent data-[state=checked]:text-accent-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
       className,
     )}
     {...props}

--- a/frontend/src/pages/Expenses.tsx
+++ b/frontend/src/pages/Expenses.tsx
@@ -471,7 +471,7 @@ const Expenses = () => {
                   };
                 }),
             ].sort((a, b) => (b.actualAmount ?? b.budget ?? 0) - (a.actualAmount ?? a.budget ?? 0))}
-            subscriptions={[...subscriptions].sort((a, b) => parseFloat(String(b.amount)) - parseFloat(String(a.amount))).map(sub => {
+            subscriptions={[...subscriptions].sort((a, b) => parseFloat(String(b.budget)) - parseFloat(String(a.budget))).map(sub => {
               // Calculate if this subscription is due in current financial month
               let isDue = false;
               if (sub.billing_cycle === 'yearly' && sub.billing_month && sub.billing_day) {
@@ -661,7 +661,7 @@ const Expenses = () => {
             id: editingSubscription.id,
             name: editingSubscription.name,
             service: editingSubscription.service,
-            amount: editingSubscription.amount,
+            budget: editingSubscription.budget,
             billing_cycle: editingSubscription.billing_cycle,
             category: editingSubscription.category,
             notes: editingSubscription.notes,

--- a/frontend/src/pages/Expenses.tsx
+++ b/frontend/src/pages/Expenses.tsx
@@ -37,7 +37,7 @@ import { useHouseholdSubjects } from "@/hooks/useHouseholdSubjects";
 
 const Expenses = () => {
   const { user } = useAuth();
-  const { household, members, coParents, dataVersion } = useHousehold();
+  const { household, members, coParents, loading: householdLoading, dataVersion } = useHousehold();
   const { isUnlocked } = useEncryption();
   const [subjectsRefreshKey, setSubjectsRefreshKey] = useState(0);
   const subjects = useHouseholdSubjects(household?.id, subjectsRefreshKey);
@@ -200,10 +200,15 @@ const Expenses = () => {
   }, [user?.id, household?.id, household?.financial_month_start, selectedMonth, isUnlocked, dataVersion]);
 
   useEffect(() => {
-    if (household?.id) {
-      fetchData();
+    if (householdLoading) return;
+    if (!household?.id) {
+      // Stranded after leave — surface the empty / locked state below
+      // instead of holding the skeleton open.
+      setLoading(false);
+      return;
     }
-  }, [household?.id, fetchData]);
+    fetchData();
+  }, [householdLoading, household?.id, fetchData]);
 
   const [editingCategory, setEditingCategory] = useState<any | null>(null);
   const [editDialogOpen, setEditDialogOpen] = useState(false);

--- a/frontend/src/pages/Income.tsx
+++ b/frontend/src/pages/Income.tsx
@@ -205,9 +205,14 @@ const Income = () => {
   }, [household?.id, financialMonthStart, selectedMonth, user?.id, isUnlocked, dataVersion]);
 
   useEffect(() => {
-    if (!householdLoading && household?.id) {
-      fetchData();
+    if (householdLoading) return;
+    if (!household?.id) {
+      // Stranded after leave — release the skeleton so VaultLockedAlert or
+      // the empty state below can surface.
+      setLoading(false);
+      return;
     }
+    fetchData();
   }, [householdLoading, household?.id, fetchData]);
 
   const [sourceDialogOpen, setSourceDialogOpen] = useState(false);

--- a/frontend/src/pages/Overview.tsx
+++ b/frontend/src/pages/Overview.tsx
@@ -125,7 +125,14 @@ const Overview = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      if (!user || !household?.id || householdLoading) return;
+      if (!user || householdLoading) return;
+      // Stranded after leave: HouseholdContext finished with no active
+      // household. Drop loading so the VaultLockedAlert below can surface and
+      // the user can re-unlock (which triggers ensure_user_has_household).
+      if (!household?.id) {
+        setLoading(false);
+        return;
+      }
       if (!isUnlocked) {
         setLoading(false);
         return;
@@ -349,7 +356,7 @@ const Overview = () => {
 
     fetchData();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [household?.id, isUnlocked, selectedMonth, dataVersion]);
+  }, [household?.id, householdLoading, isUnlocked, selectedMonth, dataVersion]);
 
   useEffect(() => {
     const checkSeedData = async () => {


### PR DESCRIPTION
## Summary

Seven fixes on top of the previous main, all from dogfooding Flow 3 → Flow 4 → Flow 5 end-to-end.

- **fix(exit): preserve subject attribution when bringing items to new household** — the bring-along was setting both \`subject_id\` *and* \`member_id\` on every brought row, violating the \`*_one_attribution\` check constraint (\"only one of the two\"). Now respects the original attribution kind.
- **fix(ui): bump Checkbox to h-5 so the square corners actually read** — the primitive's \`rounded-sm\` at 16px rendered too circle-y when filled green; reads as radio-button. Bumped to 20px for unambiguous squareness everywhere Checkbox is used.
- **fix(exit): land on home after leaving, not back on Settings** — \`HouseholdCard\`'s leave flow used \`window.location.reload()\`, leaving the user on the Settings page they triggered from. Now navigates to \`/\` so the bring-along dialog pops over Overview.
- **fix(subs): rename amount→budget on edit-dialog props + sort key** — leftover from the amount-model rename. Edit dialog was reading \`editingSubscription.amount\` (undefined post-rename) — Amount field rendered as 0. Sort key was also broken (NaN compare → no-op).
- **feat(exit): resolve subject collisions when bringing items along** — when a brought subject's name+type already exists in the destination household, a non-dismissable resolution dialog now asks the user per-collision: \"Same as the existing X?\" (merge into existing) or \"Different — keep mine separately\" (inline rename, falls back to \`{name} (2)\`). Replaces the prior silent-duplicate behavior.
- **fix(pages): release skeleton when stranded after leave** — Overview/Income/Expenses all had a fetch effect that early-returned on \`!household?.id\` without dropping local \`loading\`, leaving the user stuck on a skeleton with no UserMenu and no path to re-unlock. Now releases the skeleton so the VaultLockedAlert surfaces and \`unlockWithPassword\` can run \`ensure_user_has_household\`.
- **feat(subjects): show live connection count per subject** — \`ManageSubjectsDialog\` now shows \`N connection(s)\` next to each subject's name (counts live, non-archived rows across expenses + subscriptions + insurances). Disambiguates duplicates so you can tell which one to delete.

## Test plan

- [ ] Flow 3 → Flow 4 → Flow 5 end-to-end runs clean (re-tested locally; all check items pass).
- [ ] Bringing items with subject-attribution succeeds (was failing on the check constraint).
- [ ] Bringing a subject whose name collides with an existing one in the destination → collision dialog pops, user picks merge or rename, flow proceeds correctly.
- [ ] After leaving, user lands on Overview with the bring-along dialog over it (not stuck on Settings).
- [ ] Subscription edit dialog shows the correct amount.
- [ ] Settings → Subjects shows \`N connection(s)\` per row.

## Follow-up

- [#70](https://github.com/wahdanz1/household-harmony/issues/70) — Past-month rows as historical details view. The archived-source FK isn't being honored in past-month queries today (Income/Expenses/Overview filter sources by \`archived_at IS NULL\` regardless of viewed month) — to be addressed alongside the Details dialog work in #70.