### PR TITLE
Past-month fetches: honor archived FK so history renders

### DIFF
--- a/frontend/src/pages/Expenses.tsx
+++ b/frontend/src/pages/Expenses.tsx
@@ -120,13 +120,33 @@ const Expenses = () => {
     const startStr = format(fetchStart, "yyyy-MM-dd");
     const endStr = format(fetchEnd, "yyyy-MM-dd");
 
+    // Past months are historical: include archived/inactive sources so their
+    // monthly_* rows still resolve names + amounts.
+    const isPastMonth = fetchMonth < todayMonth;
+
+    let expensesQuery = supabase.from("expenses").select("*").eq("household_id", household.id);
+    if (!isPastMonth) {
+      expensesQuery = expensesQuery.eq("is_active", true).is("archived_at", null);
+    }
+    expensesQuery = expensesQuery.order("sort_order");
+
+    let subscriptionsQuery = supabase.from("subscriptions").select("*").eq("household_id", household.id);
+    if (!isPastMonth) {
+      subscriptionsQuery = subscriptionsQuery.is("archived_at", null);
+    }
+
+    let insurancesQuery = supabase.from("insurances").select("*").eq("household_id", household.id);
+    if (!isPastMonth) {
+      insurancesQuery = insurancesQuery.is("archived_at", null);
+    }
+
     let results;
     try {
       results = await Promise.all([
-        supabase.from("expenses").select("*").eq("household_id", household.id).eq("is_active", true).is("archived_at", null).order("sort_order"),
+        expensesQuery,
         supabase.from("monthly_expenses").select("*").eq("household_id", household.id).gte("month_end", startStr).lte("month_start", endStr),
-        supabase.from("subscriptions").select("*").eq("household_id", household.id).is("archived_at", null),
-        supabase.from("insurances").select("*").eq("household_id", household.id).is("archived_at", null),
+        subscriptionsQuery,
+        insurancesQuery,
       ]);
     } catch (err) {
       reportFailure(err);

--- a/frontend/src/pages/Income.tsx
+++ b/frontend/src/pages/Income.tsx
@@ -143,10 +143,22 @@ const Income = () => {
     const startStr = format(fetchStart, "yyyy-MM-dd");
     const endStr = format(fetchEnd, "yyyy-MM-dd");
 
+    // Past months are historical: include archived/inactive sources so their
+    // monthly_* rows still resolve names + amounts.
+    const isPastMonth = fetchMonth < todayMonth;
+
+    let sourcesQuery = supabase.from("income_sources")
+      .select("*, profiles(full_name, avatar_url)")
+      .eq("household_id", household.id);
+    if (!isPastMonth) {
+      sourcesQuery = sourcesQuery.eq("is_active", true).is("archived_at", null);
+    }
+    sourcesQuery = sourcesQuery.order("created_at", { ascending: true });
+
     let sourcesResult, monthlyResult;
     try {
       [sourcesResult, monthlyResult] = await Promise.all([
-        supabase.from("income_sources").select("*, profiles(full_name, avatar_url)").eq("household_id", household.id).eq("is_active", true).is("archived_at", null).order("created_at", { ascending: true }),
+        sourcesQuery,
         supabase.from("monthly_incomes").select("*").eq("household_id", household.id).gte("month_end", startStr).lte("month_start", endStr),
       ]);
     } catch (err) {

--- a/frontend/src/pages/Overview.tsx
+++ b/frontend/src/pages/Overview.tsx
@@ -149,15 +149,31 @@ const Overview = () => {
       const startStr = format(fetchStart, "yyyy-MM-dd");
       const endStr = format(fetchEnd, "yyyy-MM-dd");
 
+      // Past months are historical: include archived/inactive sources so their
+      // monthly_* rows still contribute to totals.
+      const isPastMonth = selectedMonth < todayMonth;
+
+      let incomeQuery = supabase.from("income_sources").select("id, encrypted_budget, is_encrypted").eq("household_id", household.id);
+      if (!isPastMonth) incomeQuery = incomeQuery.eq("is_active", true).is("archived_at", null);
+
+      let expenseQuery = supabase.from("expenses").select("id, encrypted_budget, is_encrypted").eq("household_id", household.id);
+      if (!isPastMonth) expenseQuery = expenseQuery.is("archived_at", null);
+
+      let subscriptionQuery = supabase.from("subscriptions").select("encrypted_budget, billing_cycle, billing_month, billing_day, is_encrypted").eq("household_id", household.id);
+      if (!isPastMonth) subscriptionQuery = subscriptionQuery.eq("is_active", true).is("archived_at", null);
+
+      let insuranceQuery = supabase.from("insurances").select("encrypted_budget, billing_cycle, is_shared, share_percentage, is_encrypted").eq("household_id", household.id);
+      if (!isPastMonth) insuranceQuery = insuranceQuery.eq("is_active", true).is("archived_at", null);
+
       let results;
       try {
         results = await Promise.all([
-          supabase.from("income_sources").select("id, encrypted_budget, is_encrypted").eq("household_id", household.id).eq("is_active", true).is("archived_at", null),
+          incomeQuery,
           supabase.from("monthly_incomes").select("*").eq("household_id", household.id).gte("month_end", startStr).lte("month_start", endStr),
-          supabase.from("expenses").select("id, encrypted_budget, is_encrypted").eq("household_id", household.id).is("archived_at", null),
+          expenseQuery,
           supabase.from("monthly_expenses").select("*").eq("household_id", household.id).gte("month_end", startStr).lte("month_start", endStr),
-          supabase.from("subscriptions").select("encrypted_budget, billing_cycle, billing_month, billing_day, is_encrypted").eq("household_id", household.id).eq("is_active", true).is("archived_at", null),
-          supabase.from("insurances").select("encrypted_budget, billing_cycle, is_shared, share_percentage, is_encrypted").eq("household_id", household.id).eq("is_active", true).is("archived_at", null),
+          subscriptionQuery,
+          insuranceQuery,
           supabase.from("shared_expenses").select("id, encrypted_amount, encrypted_description, paid_by, is_encrypted, created_at").eq("household_id", household.id).gte("month_end", startStr).lte("month_start", endStr).order("created_at", { ascending: false }),
         ]);
       } catch (err) {


### PR DESCRIPTION
Closes [#74](https://github.com/wahdanz1/household-harmony/issues/74). Part 1 of [#70](https://github.com/wahdanz1/household-harmony/issues/70).

## Summary

When viewing a past month, drop the \`archived_at IS NULL\` and \`is_active = true\` filters on source-table fetches. The \`monthly_*\` rows already exist for that month and reference their (now-archived/inactive) sources via FK — without including those sources in the fetch, the page can't resolve names and Overview totals understate.

## Files

- [Income.tsx](frontend/src/pages/Income.tsx) — \`income_sources\` query
- [Expenses.tsx](frontend/src/pages/Expenses.tsx) — \`expenses\`, \`subscriptions\`, \`insurances\` queries
- [Overview.tsx](frontend/src/pages/Overview.tsx) — same four source tables

Trigger condition: \`selectedMonth < todayMonth\`. Current month and future months keep the original live-only filters.

## Test plan

- [ ] Sign in as User A (whose household had a member leave and take items).
- [ ] Navigate Income page back one month: items brought away by the leaver should now appear with their actuals.
- [ ] Same on Expenses page.
- [ ] Overview totals for the past month should include those amounts.
- [ ] Current-month view unchanged — only live sources appear.

## Follow-up

[#75](https://github.com/wahdanz1/household-harmony/issues/75) — Part 2: Details dialog + read-only lockdown for past months.