### PR TITLE
Past-month details dialog + read-only lockdown

### DIFF
--- a/frontend/src/components/expenses/AllTabBlockView.tsx
+++ b/frontend/src/components/expenses/AllTabBlockView.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { ChevronDown, ChevronRight, Pencil, AlertTriangle, Sparkles, Car, Baby, PawPrint, Box, Plus, CreditCard, User, Zap } from "lucide-react";
+import { ChevronDown, ChevronRight, Pencil, Info, AlertTriangle, Sparkles, Car, Baby, PawPrint, Box, Plus, CreditCard, User, Zap } from "lucide-react";
 import { CatIcon } from "@/components/ui/cat-icon";
 import { ServiceIcon } from "@/components/ui/service-icon";
 import { Money } from "@/components/ui/money";
@@ -21,6 +21,11 @@ interface ExpenseItem {
     budget?: number;
     /** Realised amount from a credit-card invoice. When set and ≠ amount, a variance badge is shown. */
     actualAmount?: number;
+    /** Audit metadata from monthly_* used by the past-month Details dialog. */
+    previousBudgetSnapshot?: number;
+    budgetChangedAt?: string;
+    actualRecordedAt?: string;
+    inactivatedAt?: string;
     category?: string;
     // Optional custom display (e.g., "1780 SEK/year" instead of calculated monthly)
     displayAmount?: number;
@@ -93,6 +98,8 @@ interface ExpenseBlockProps {
     onAmountChange?: (id: string, amount: string) => void;
     editable?: boolean;
     onAdd?: () => void;
+    /** Past-month read-only mode: pencil hover becomes info icon. */
+    pastMonth?: boolean;
 }
 
 /**
@@ -112,6 +119,7 @@ export const ExpenseBlock = ({
     onAmountChange,
     editable = false,
     onAdd,
+    pastMonth = false,
 }: ExpenseBlockProps) => {
     const [isExpanded, setIsExpanded] = useState(false);
     const blockRef = useRef<HTMLDivElement>(null);
@@ -244,7 +252,10 @@ export const ExpenseBlock = ({
                                         {item.isOneOff && <OneOffChip />}
                                     </div>
                                 </div>
-                                <div className="flex items-center gap-2 shrink-0" onClick={(e) => e.stopPropagation()}>
+                                <div
+                                    className="flex items-center gap-2 shrink-0"
+                                    onClick={editable && onAmountChange ? (e) => e.stopPropagation() : undefined}
+                                >
                                     {editable && onAmountChange ? (
                                         <MoneyInput
                                             value={item.amount}
@@ -283,7 +294,11 @@ export const ExpenseBlock = ({
                                             estimate={categoryType === 'expense' && isCategoryBudgeted(item.category)}
                                         />
                                     )}
-                                    <Pencil className="h-3.5 w-3.5 text-muted hidden md:block md:opacity-0 md:group-hover:opacity-100 transition-opacity" />
+                                    {pastMonth ? (
+                                        <Info className="h-3.5 w-3.5 text-muted hidden md:block md:opacity-0 md:group-hover:opacity-100 transition-opacity" />
+                                    ) : (
+                                        <Pencil className="h-3.5 w-3.5 text-muted hidden md:block md:opacity-0 md:group-hover:opacity-100 transition-opacity" />
+                                    )}
                                 </div>
                             </RowItem>
                         );
@@ -320,6 +335,7 @@ interface AllTabBlockViewProps {
     onAddSubscription?: () => void;
     onAddInsurance?: () => void;
     onAmountChange?: (id: string, amount: string) => void;
+    pastMonth?: boolean;
 }
 
 /**
@@ -339,6 +355,7 @@ export const AllTabBlockView = ({
     onAddSubscription,
     onAddInsurance,
     onAmountChange,
+    pastMonth = false,
 }: AllTabBlockViewProps) => {
     const expensesTotal = expenses.reduce((sum, item) => sum + item.amount, 0);
     const expensesBudgetedTotal = expenses
@@ -426,6 +443,7 @@ export const AllTabBlockView = ({
                     onItemClick={onExpenseClick}
                     editable={!!onAmountChange}
                     onAmountChange={onAmountChange}
+                    pastMonth={pastMonth}
                     headerMetrics={
                         <SectionFrames frames={[
                             { v: expensesTotal, unit: "kr/mo", primary: true },
@@ -442,7 +460,8 @@ export const AllTabBlockView = ({
                 items={subscriptionItems}
                 categoryType="subscription"
                 onItemClick={onSubscriptionClick}
-                onAdd={onAddSubscription}
+                onAdd={pastMonth ? undefined : onAddSubscription}
+                pastMonth={pastMonth}
                 severity={subscriptionSeverity}
                 severityMessage={
                     subscriptionSeverity === 'danger'
@@ -468,7 +487,8 @@ export const AllTabBlockView = ({
                 items={insuranceItems}
                 categoryType="insurance"
                 onItemClick={onInsuranceClick}
-                onAdd={onAddInsurance}
+                onAdd={pastMonth ? undefined : onAddInsurance}
+                pastMonth={pastMonth}
                 headerMetrics={insuranceTotal > 0 ? (
                     <SectionFrames frames={[
                         { v: insuranceTotal, unit: "kr/mo", primary: true },

--- a/frontend/src/components/income/IncomeSourceItem.tsx
+++ b/frontend/src/components/income/IncomeSourceItem.tsx
@@ -1,4 +1,4 @@
-import { Pencil, Sparkles } from "lucide-react";
+import { Pencil, Info, Sparkles } from "lucide-react";
 import { getIncomeCategoryById } from "@/constants/incomeCategories";
 import { RowItem } from "@/components/ui/row-item";
 import { Money } from "@/components/ui/money";
@@ -13,6 +13,8 @@ interface IncomeSourceItemProps {
     currency: string;
     onEdit: (source: any) => void;
     readOnly?: boolean;
+    /** Past-month read-only mode: pencil hover becomes info icon. Click still fires. */
+    pastMonth?: boolean;
     /** Set true on the last item of the list to drop the bottom divider. */
     last?: boolean;
 }
@@ -24,6 +26,7 @@ export const IncomeSourceItem = ({
     currency,
     onEdit,
     readOnly = false,
+    pastMonth = false,
     last = false,
 }: IncomeSourceItemProps) => {
     const isSkipped = amount === 0;
@@ -75,7 +78,11 @@ export const IncomeSourceItem = ({
                 />
 
                 {!readOnly && (
-                    <Pencil className="h-3.5 w-3.5 text-muted hidden md:block md:opacity-0 md:group-hover:opacity-100 transition-opacity" />
+                    pastMonth ? (
+                        <Info className="h-3.5 w-3.5 text-muted hidden md:block md:opacity-0 md:group-hover:opacity-100 transition-opacity" />
+                    ) : (
+                        <Pencil className="h-3.5 w-3.5 text-muted hidden md:block md:opacity-0 md:group-hover:opacity-100 transition-opacity" />
+                    )
                 )}
             </div>
         </RowItem>

--- a/frontend/src/components/shared/PastMonthDetailsDialog.tsx
+++ b/frontend/src/components/shared/PastMonthDetailsDialog.tsx
@@ -1,0 +1,167 @@
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Money } from "@/components/ui/money";
+import { CatIcon } from "@/components/ui/cat-icon";
+import { CreditCard, User, Zap, Box, Car, Baby, PawPrint, Sparkles } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { format } from "date-fns";
+
+const SUBJECT_TYPE_ICON: Record<string, LucideIcon> = {
+    car: Car,
+    kid: Baby,
+    pet: PawPrint,
+    other: Box,
+};
+
+export interface PastMonthDetailsItem {
+    name: string;
+    categoryLabel?: string;
+    icon?: LucideIcon;
+    hue?: number;
+    currency: string;
+    /** Planned amount (budget snapshot for source-tied rows). Omitted for one-time entries. */
+    budget?: number;
+    /** Realised amount for the month. Always set for one-time entries; may be absent for unreconciled source-tied rows. */
+    actualAmount?: number;
+    /** Audit metadata from monthly_*: was budget changed mid-month? */
+    previousBudgetSnapshot?: number;
+    budgetChangedAt?: string;
+    /** Audit metadata: was actual recorded outside Review (via Mark paid)? */
+    actualRecordedAt?: string;
+    /** Audit metadata: was source inactivated mid-month? */
+    inactivatedAt?: string;
+    subject?: { name: string; type: string };
+    member?: { name: string };
+    isCredit?: boolean;
+    isOneOff?: boolean;
+    /** Per-cycle display label for subs/insurance, e.g. "/year". */
+    billingLabel?: string;
+}
+
+interface Props {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    item: PastMonthDetailsItem | null;
+}
+
+const SubjectChip = ({ subject }: { subject: { name: string; type: string } }) => {
+    const Icon = SUBJECT_TYPE_ICON[subject.type] ?? Box;
+    return (
+        <span className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded bg-surface-2 text-muted">
+            <Icon className="h-3 w-3" />
+            {subject.name}
+        </span>
+    );
+};
+
+const MemberChip = ({ member }: { member: { name: string } }) => (
+    <span className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded bg-surface-2 text-muted">
+        <User className="h-3 w-3" />
+        {member.name}
+    </span>
+);
+
+const CreditChip = () => (
+    <span className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded bg-surface-2 text-muted">
+        <CreditCard className="h-3 w-3" />
+        Credit
+    </span>
+);
+
+const OneOffChip = () => (
+    <span className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded bg-surface-2 text-muted">
+        <Zap className="h-3 w-3" />
+        One-off
+    </span>
+);
+
+export const PastMonthDetailsDialog = ({ open, onOpenChange, item }: Props) => {
+    if (!item) return null;
+
+    const Icon = item.icon ?? Sparkles;
+    const hasBudget = item.budget !== undefined;
+    const hasActual = item.actualAmount !== undefined;
+    const variance = hasBudget && hasActual ? item.actualAmount! - item.budget! : null;
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle className="flex items-center gap-3 min-w-0">
+                        <CatIcon icon={Icon} hue={item.hue} size={36} />
+                        <div className="flex-1 min-w-0">
+                            <div className="truncate">{item.name}</div>
+                            <div className="flex items-center gap-1.5 mt-1 flex-wrap">
+                                {item.subject && <SubjectChip subject={item.subject} />}
+                                {item.member && <MemberChip member={item.member} />}
+                                {item.isCredit && <CreditChip />}
+                                {item.isOneOff && <OneOffChip />}
+                            </div>
+                        </div>
+                    </DialogTitle>
+                    {item.categoryLabel && (
+                        <DialogDescription>{item.categoryLabel}</DialogDescription>
+                    )}
+                </DialogHeader>
+
+                <div className="space-y-3 py-2">
+                    {hasBudget && (
+                        <div className="flex items-baseline justify-between">
+                            <span className="text-sm text-muted">Planned</span>
+                            <span className="flex items-baseline gap-1">
+                                <Money v={item.budget!} currency={item.currency} weight={500} />
+                                {item.billingLabel && <span className="text-xs text-muted">{item.billingLabel}</span>}
+                            </span>
+                        </div>
+                    )}
+
+                    {hasActual && (
+                        <div className="flex items-baseline justify-between">
+                            <span className="text-sm text-muted">Actual</span>
+                            <span className="flex items-baseline gap-1">
+                                <Money v={item.actualAmount!} currency={item.currency} weight={600} />
+                                {!hasBudget && item.billingLabel && (
+                                    <span className="text-xs text-muted">{item.billingLabel}</span>
+                                )}
+                            </span>
+                        </div>
+                    )}
+
+                    {variance != null && Math.round(variance) !== 0 && (
+                        <div className="flex items-baseline justify-between">
+                            <span className="text-sm text-muted">Variance</span>
+                            <span className={`text-sm font-semibold tabular-nums ${variance > 0 ? "text-danger" : "text-accent"}`}>
+                                {variance > 0 ? "+" : "−"}{Math.abs(Math.round(variance)).toLocaleString("sv-SE")} {item.currency}
+                            </span>
+                        </div>
+                    )}
+
+                    {(item.budgetChangedAt || item.actualRecordedAt || item.inactivatedAt) && (
+                        <div className="pt-2 border-t border-line-2 space-y-1.5">
+                            {item.budgetChangedAt && item.previousBudgetSnapshot != null && (
+                                <p className="text-xs text-muted">
+                                    Budget changed {format(new Date(item.budgetChangedAt), "d MMM")} — was{" "}
+                                    {Math.round(item.previousBudgetSnapshot).toLocaleString("sv-SE")} {item.currency}
+                                </p>
+                            )}
+                            {item.actualRecordedAt && (
+                                <p className="text-xs text-muted">
+                                    Actual recorded {format(new Date(item.actualRecordedAt), "d MMM")} (outside Review)
+                                </p>
+                            )}
+                            {item.inactivatedAt && (
+                                <p className="text-xs text-muted">
+                                    Inactivated {format(new Date(item.inactivatedAt), "d MMM")}
+                                </p>
+                            )}
+                        </div>
+                    )}
+                </div>
+
+                <DialogFooter>
+                    <Button variant="outline" onClick={() => onOpenChange(false)}>Close</Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};

--- a/frontend/src/pages/Expenses.tsx
+++ b/frontend/src/pages/Expenses.tsx
@@ -27,6 +27,8 @@ import { useEncryptedFields, expenseFields, monthlyExpenseFields, subscriptionFi
 import { subscriptionCategories } from "@/constants/subscriptionCategories";
 import { insuranceTypes } from "@/constants/insuranceTypes";
 import { VaultLockedAlert } from "@/components/shared/VaultLockedAlert";
+import { PastMonthDetailsDialog, PastMonthDetailsItem } from "@/components/shared/PastMonthDetailsDialog";
+import { getCategoryById } from "@/constants/expenseCategories";
 import { useEncryption } from "@/contexts/EncryptionContext";
 import { ExpensesPageSkeleton } from "@/components/shared/skeletons/PageSkeletons";
 import { AvatarTrigger } from "@/components/shared/AvatarTrigger";
@@ -54,6 +56,7 @@ const Expenses = () => {
 
   const [editingSubscription, setEditingSubscription] = useState<any | null>(null);
   const [editingInsurance, setEditingInsurance] = useState<any | null>(null);
+  const [detailsItem, setDetailsItem] = useState<PastMonthDetailsItem | null>(null);
 
   const financialMonthStart = household?.financial_month_start || 25;
 
@@ -61,6 +64,7 @@ const Expenses = () => {
   const todayMonth = getCurrentFinancialMonth(financialMonthStart);
   const [selectedMonth, setSelectedMonth] = useState(todayMonth);
   const isCurrentMonth = selectedMonth === todayMonth;
+  const isPastMonth = selectedMonth < todayMonth;
 
   // The review gate only applies once a previous financial month exists with
   // data — fresh households on their very first month aren't asked to review
@@ -433,6 +437,7 @@ const Expenses = () => {
             />
           ) : (
           <>
+          {!isPastMonth && (
           <div className="hidden sm:grid grid-cols-2 gap-5">
             <Button
               size="lg"
@@ -454,6 +459,7 @@ const Expenses = () => {
               One-off
             </Button>
           </div>
+          )}
 
           <AllTabBlockView
             expenses={[
@@ -475,6 +481,10 @@ const Expenses = () => {
                   subject: subj ? { name: subj.name, type: subj.type } : undefined,
                   member: mem ? { name: mem.profiles?.full_name ?? "Member" } : undefined,
                   isCredit: !!cat.is_credit,
+                  previousBudgetSnapshot: monthly?.previous_budget_snapshot != null ? Number(monthly.previous_budget_snapshot) : undefined,
+                  budgetChangedAt: monthly?.budget_changed_at ?? undefined,
+                  actualRecordedAt: monthly?.actual_recorded_at ?? undefined,
+                  inactivatedAt: monthly?.inactivated_at ?? undefined,
                 };
               }),
               // One-time entries (e.g. from credit-import for un-budgeted
@@ -484,6 +494,9 @@ const Expenses = () => {
                 .filter((m: any) => m.expense_id == null && m.one_time_name)
                 .map((m: any) => {
                   const actualAmount = m.actual_amount != null ? Number(m.actual_amount) : undefined;
+                  // Past months: click opens Details. Current month: no edit
+                  // surface yet, so row stays non-interactive.
+                  const readOnly = !isPastMonth;
                   return {
                     id: `onetime-${m.id}`,
                     name: m.one_time_name as string,
@@ -492,7 +505,7 @@ const Expenses = () => {
                     actualAmount,
                     category: m.one_time_category as string | undefined,
                     isOneOff: true,
-                    readOnly: true,
+                    readOnly,
                   };
                 }),
             ].sort((a, b) => (b.actualAmount ?? b.budget ?? 0) - (a.actualAmount ?? a.budget ?? 0))}
@@ -566,23 +579,106 @@ const Expenses = () => {
             insuranceTotal={insuranceTotal}
             subscriptionSeverity={subscriptionSeverity}
             currency={household?.currency || "SEK"}
+            pastMonth={isPastMonth}
             onExpenseClick={(id) => {
+              if (id.startsWith("onetime-")) {
+                if (!isPastMonth) return;
+                const monthlyId = id.slice("onetime-".length);
+                const monthly = monthlyExpenses.find((m: any) => m.id === monthlyId);
+                if (!monthly) return;
+                const cat = getCategoryById(monthly.one_time_category);
+                setDetailsItem({
+                  name: monthly.one_time_name,
+                  categoryLabel: cat?.label,
+                  icon: cat?.icon,
+                  hue: cat?.hue,
+                  currency: household?.currency || "SEK",
+                  actualAmount: monthly.actual_amount != null ? Number(monthly.actual_amount) : undefined,
+                  isOneOff: true,
+                });
+                return;
+              }
               const expense = expenseCategories.find(cat => cat.id === id);
-              if (expense) handleEditCategory(expense);
+              if (!expense) return;
+              if (isPastMonth) {
+                const monthly = monthlyExpenses.find((m: any) => m.expense_id === expense.id);
+                const cat = getCategoryById(expense.category);
+                const subj = subjects.find(s => s.id === expense.subject_id);
+                const mem = members.find(m => m.id === expense.member_id);
+                setDetailsItem({
+                  name: expense.name,
+                  categoryLabel: cat?.label,
+                  icon: cat?.icon,
+                  hue: cat?.hue,
+                  currency: household?.currency || "SEK",
+                  budget: parseFloat(expense.budget || "0"),
+                  actualAmount: monthly?.actual_amount != null ? Number(monthly.actual_amount) : undefined,
+                  previousBudgetSnapshot: monthly?.previous_budget_snapshot != null ? Number(monthly.previous_budget_snapshot) : undefined,
+                  budgetChangedAt: monthly?.budget_changed_at ?? undefined,
+                  actualRecordedAt: monthly?.actual_recorded_at ?? undefined,
+                  inactivatedAt: monthly?.inactivated_at ?? undefined,
+                  subject: subj ? { name: subj.name, type: subj.type } : undefined,
+                  member: mem ? { name: mem.profiles?.full_name ?? "Member" } : undefined,
+                  isCredit: !!expense.is_credit,
+                });
+                return;
+              }
+              handleEditCategory(expense);
             }}
             onAddSubscription={() => !isReadOnly && setAddSubscriptionOpen(true)}
             onAddInsurance={() => !isReadOnly && setAddInsuranceOpen(true)}
             onSubscriptionClick={(id) => {
               const subscription = subscriptions.find(s => s.id === id);
-              if (subscription) setEditingSubscription(subscription);
+              if (!subscription) return;
+              if (isPastMonth) {
+                const cat = subscriptionCategories.find(c => c.value === subscription.category);
+                const subj = subjects.find(s => s.id === subscription.subject_id);
+                const mem = members.find(m => m.id === subscription.member_id);
+                const cycleLabels: Record<string, string> = { yearly: "/year", quarterly: "/quarter", monthly: "/month", semi_annually: "/6 mo" };
+                setDetailsItem({
+                  name: subscription.name || subscription.service,
+                  categoryLabel: cat?.label,
+                  icon: cat?.icon,
+                  hue: cat?.hue,
+                  currency: household?.currency || "SEK",
+                  budget: parseFloat(String(subscription.budget || 0)),
+                  billingLabel: cycleLabels[subscription.billing_cycle] || "/month",
+                  subject: subj ? { name: subj.name, type: subj.type } : undefined,
+                  member: mem ? { name: mem.profiles?.full_name ?? "Member" } : undefined,
+                });
+                return;
+              }
+              setEditingSubscription(subscription);
             }}
             onInsuranceClick={(id) => {
               const insurance = insurances.find(i => i.id === id);
-              if (insurance) setEditingInsurance(insurance);
+              if (!insurance) return;
+              if (isPastMonth) {
+                const cat = insuranceTypes.find(t => t.value === insurance.category);
+                const subj = subjects.find(s => s.id === insurance.subject_id);
+                const mem = members.find(m => m.id === insurance.member_id);
+                const cycleLabels: Record<string, string> = { yearly: "/year", quarterly: "/quarter", monthly: "/month", semi_annually: "/6 mo" };
+                const rawName = typeof insurance.name === "string" ? insurance.name.trim() : "";
+                const customName = rawName === "NaN" ? "" : rawName;
+                setDetailsItem({
+                  name: customName || cat?.label || "Insurance",
+                  categoryLabel: cat?.label,
+                  icon: cat?.icon,
+                  hue: cat?.hue,
+                  currency: household?.currency || "SEK",
+                  budget: parseFloat(String(insurance.budget || 0)),
+                  billingLabel: cycleLabels[insurance.billing_cycle] || "/month",
+                  subject: subj ? { name: subj.name, type: subj.type } : undefined,
+                  member: mem ? { name: mem.profiles?.full_name ?? "Member" } : undefined,
+                });
+                return;
+              }
+              setEditingInsurance(insurance);
             }}
           />
 
 
+          {!isPastMonth && (
           <MobileBottomBar>
             <Button
               size="lg"
@@ -604,6 +700,7 @@ const Expenses = () => {
               One-off
             </Button>
           </MobileBottomBar>
+          )}
           </>
           )}
         </TabsContent>
@@ -743,6 +840,12 @@ const Expenses = () => {
           onSuccess={fetchData}
         />
       )}
+
+      <PastMonthDetailsDialog
+        open={!!detailsItem}
+        onOpenChange={(o) => !o && setDetailsItem(null)}
+        item={detailsItem}
+      />
     </div>
   );
 };

--- a/frontend/src/pages/Income.tsx
+++ b/frontend/src/pages/Income.tsx
@@ -17,6 +17,8 @@ import { format } from "date-fns";
 import { IncomeSourceItem } from "@/components/income/IncomeSourceItem";
 import { IncomeFormDialog } from "@/components/income/IncomeFormDialog";
 import { OneTimeIncomeDialog } from "@/components/income/OneTimeIncomeDialog";
+import { PastMonthDetailsDialog, PastMonthDetailsItem } from "@/components/shared/PastMonthDetailsDialog";
+import { getIncomeCategoryById } from "@/constants/incomeCategories";
 
 import { getCurrentFinancialMonth, getFinancialMonthRange } from "@/utils/dateUtils";
 import { reportSuccess, reportFailure, isDown } from "@/utils/outageMonitor";
@@ -89,6 +91,7 @@ const Income = () => {
   const todayMonth = getCurrentFinancialMonth(financialMonthStart);
   const [selectedMonth, setSelectedMonth] = useState(todayMonth);
   const isCurrentMonth = selectedMonth === todayMonth;
+  const isPastMonthView = selectedMonth < todayMonth;
 
   // The review gate only applies once a previous financial month exists with
   // data — fresh households on their very first month aren't asked to review
@@ -229,7 +232,26 @@ const Income = () => {
 
   const [sourceDialogOpen, setSourceDialogOpen] = useState(false);
   const [editingSource, setEditingSource] = useState<any | null>(null);
+  const [detailsItem, setDetailsItem] = useState<PastMonthDetailsItem | null>(null);
   const handleEditSource = (source: any) => {
+    if (isPastMonthView) {
+      const monthly = monthlyIncomes.find((m: any) => m.income_source_id === source.id);
+      const cat = getIncomeCategoryById(source.category);
+      setDetailsItem({
+        name: source.name || source.provider,
+        categoryLabel: cat?.label,
+        icon: cat?.icon,
+        hue: cat?.hue,
+        currency: household?.currency || "SEK",
+        budget: parseFloat(source.budget || "0"),
+        actualAmount: monthly?.actual_amount != null ? Number(monthly.actual_amount) : undefined,
+        previousBudgetSnapshot: monthly?.previous_budget_snapshot != null ? Number(monthly.previous_budget_snapshot) : undefined,
+        budgetChangedAt: monthly?.budget_changed_at ?? undefined,
+        actualRecordedAt: monthly?.actual_recorded_at ?? undefined,
+        inactivatedAt: monthly?.inactivated_at ?? undefined,
+      });
+      return;
+    }
     setEditingSource(source);
     setSourceDialogOpen(true);
   };
@@ -343,7 +365,7 @@ const Income = () => {
         </Alert>
       )}
 
-      {hasAnySource && (
+      {hasAnySource && !isPastMonthView && (
         <div className="hidden sm:grid grid-cols-2 gap-5">
           <Button
             size="lg"
@@ -393,6 +415,7 @@ const Income = () => {
                   currency={household?.currency || "SEK"}
                   onEdit={handleEditSource}
                   readOnly={isReadOnly}
+                  pastMonth={isPastMonthView}
                   last={idx === incomeSources.length - 1}
                 />
               );
@@ -401,7 +424,7 @@ const Income = () => {
         </Card>
       )}
 
-      {hasAnySource && (
+      {hasAnySource && !isPastMonthView && (
         <MobileBottomBar>
           <Button
             size="lg"
@@ -452,6 +475,12 @@ const Income = () => {
           onSuccess={fetchData}
         />
       )}
+
+      <PastMonthDetailsDialog
+        open={!!detailsItem}
+        onOpenChange={(o) => !o && setDetailsItem(null)}
+        item={detailsItem}
+      />
     </div >
   );
 };


### PR DESCRIPTION
Closes [#75](https://github.com/wahdanz1/household-harmony/issues/75). Part 2 of [#70](https://github.com/wahdanz1/household-harmony/issues/70). Builds on #74 (historical fetch).

## Summary

Past months are now strictly read-only on Income, Expenses, and their nested surfaces. Clicking a row opens a Details dialog instead of the edit dialog; Add buttons are hidden; the hover-pencil swaps to an info icon.

- **New: \`PastMonthDetailsDialog\`** ([components/shared/](frontend/src/components/shared/PastMonthDetailsDialog.tsx)) — single shared dialog handling source-tied rows (income / expense / subscription / insurance), one-time entries, and the audit pills (Changed mid-month / Recorded outside Review / Inactivated). Close-only, no edit/delete.
- **\`AllTabBlockView\`** — new \`pastMonth\` prop. Pencil hover swaps to \`Info\`. When true, the parent omits \`onAdd\` callbacks so the \`+ Add subscription / + Add insurance\` row-footer hides.
- **\`IncomeSourceItem\`** — same \`pastMonth\` prop, same pencil → info swap.
- **Expenses.tsx** — routes past-month row clicks (expense source / subscription / insurance / one-time entry) to the Details dialog with all the relevant fields including audit metadata. Top-row Add buttons + MobileBottomBar hidden when past.
- **Income.tsx** — routes past-month \`IncomeSourceItem\` clicks to the Details dialog with audit metadata. Add Source / OneTime buttons hidden when past on both desktop and mobile.
- **Click bubbling fix** — the right-side wrapper in \`ExpenseBlock\` had unconditional \`stopPropagation\` blocking clicks on the Pencil/Info icon from reaching the RowItem. Made the stop conditional on the editable+\`onAmountChange\` path (which is unused today), so the icon now opens the dialog like the rest of the row.

## Test plan

- [ ] Navigate to a past month on Income — Add Source / OneTime buttons gone.
- [ ] Click any income row — Details dialog opens with planned/actual/variance/audit. Close button works. No edit dialog.
- [ ] Navigate to a past month on Expenses — top Add buttons gone, AllTabBlockView's \`+ Add subscription\` / \`+ Add insurance\` rows gone, MobileBottomBar gone.
- [ ] Click an expense source row — Details with planned/actual/variance/chips/audit.
- [ ] Click a subscription / insurance — Details with budget + billing label + chips.
- [ ] Click a one-time entry (e.g. from credit-import) — Details with actual + One-off chip. No variance pill (no budget).
- [ ] Hovering a row in a past month shows \`Info\` icon (not Pencil). Clicking the icon opens the dialog.
- [ ] Navigate back to current month — everything reverts (Add buttons return, Pencil returns, clicks open edit dialog).

## Out of scope (filed)

- One-time entry delete / recategorize — corrections route through Monthly Review.
- "Plan this month" banner on future months — [#76](https://github.com/wahdanz1/household-harmony/issues/76).