### PR TITLE
Overview hotfixes: severity ref + drop count from recurring tiles

### DIFF
--- a/frontend/src/pages/Overview.tsx
+++ b/frontend/src/pages/Overview.tsx
@@ -654,7 +654,6 @@ const Overview = () => {
                     primary={data.subscriptionsMonthly}
                     primaryLabel="per month"
                     secondary={`${fmtKr(data.subscriptionsYearly, currency)}/yr`}
-                    count={data.subscriptionsCount}
                     severity={data.subscriptionsSeverity}
                     currency={currency}
                     onClick={() => navigate("/expenses?tab=all&expand=subscriptions")}
@@ -667,7 +666,6 @@ const Overview = () => {
                     primary={data.insuranceMonthly}
                     primaryLabel="per month"
                     secondary={`${fmtKr(data.insuranceYearly, currency)}/yr`}
-                    count={data.insuranceCount}
                     severity={data.insuranceSeverity}
                     currency={currency}
                     onClick={() => navigate("/expenses?tab=all&expand=insurances")}

--- a/frontend/src/pages/Overview.tsx
+++ b/frontend/src/pages/Overview.tsx
@@ -366,7 +366,7 @@ const Overview = () => {
       const computeRecurringSeverity = (sources: any[]): TileSeverity => {
         const { thisFm, nextFm } = classifySourcesByFM(
           sources.filter((s: any) => s.is_active),
-          fetchMonth,
+          selectedMonth,
           fms,
         );
         let sev: TileSeverity = "default";


### PR DESCRIPTION
Two small fixes following PR #83:

- Overview's severity compute referenced `fetchMonth` (an undefined). Renamed to `selectedMonth` (the actual local in Overview's fetchData scope).
- Drop the `count` badge from Subscriptions/Insurance tiles — it clashed visually with the new AlertTriangle warning indicator ("what's that 1 in the corner?").