### PR TITLE
One-off expenses (amount/edit/delete/attribution), shared income, member-name display

### DIFF
--- a/frontend/src/components/expenses/AllTabBlockView.tsx
+++ b/frontend/src/components/expenses/AllTabBlockView.tsx
@@ -7,6 +7,7 @@ import { RowItem } from "@/components/ui/row-item";
 import { SectionFrames } from "@/components/ui/section-frames";
 import { useEffect, useRef, useState } from "react";
 import { getCategoryById, isCategoryBudgeted } from "@/constants/expenseCategories";
+import { getOneOffCategory } from "@/constants/oneOffExpenseCategories";
 import { subscriptionCategories } from "@/constants/subscriptionCategories";
 import { insuranceTypes } from "@/constants/insuranceTypes";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -117,8 +118,7 @@ export const ExpenseBlock = ({
 }: ExpenseBlockProps) => {
     const [isExpanded, setIsExpanded] = useState(defaultExpanded);
     const blockRef = useRef<HTMLDivElement>(null);
-    // Skip the mount run so landing on the page with a section already open
-    // doesn't scroll away from the top card — only a user tap should scroll.
+    // Only a user tap should scroll; skip the mount run when a section starts open.
     const didMount = useRef(false);
 
     useEffect(() => {
@@ -133,7 +133,7 @@ export const ExpenseBlock = ({
     }, [isExpanded]);
 
     // Helper to get category info based on type
-    const getCategoryInfo = (category: string | undefined) => {
+    const getCategoryInfo = (category: string | undefined, isOneOff = false) => {
         if (!category) return null;
         if (categoryType === 'subscription') {
             return subscriptionCategories.find(c => c.value === category);
@@ -141,6 +141,9 @@ export const ExpenseBlock = ({
         if (categoryType === 'insurance') {
             return insuranceTypes.find(c => c.value === category);
         }
+        // One-offs draw from their own vocab (medical, home_repair…) which the
+        // recurring EXPENSE_CATEGORIES doesn't carry.
+        if (isOneOff) return getOneOffCategory(category);
         return getCategoryById(category);
     };
 
@@ -203,7 +206,7 @@ export const ExpenseBlock = ({
                     <div className="overflow-hidden">
                         <div className="border-t border-line-2">
                     {items.map((item, idx) => {
-                        const cat = getCategoryInfo(item.category);
+                        const cat = getCategoryInfo(item.category, item.isOneOff);
                         const Icon = cat?.icon;
                         const isLast = idx === items.length - 1;
 

--- a/frontend/src/components/expenses/TemporaryExpenseFormDialog.tsx
+++ b/frontend/src/components/expenses/TemporaryExpenseFormDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import {
-    Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
+    Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -12,59 +12,82 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useEncryptedFields, monthlyExpenseFields } from "@/hooks/useEncryptedFields";
 import { getCurrentFinancialMonth, getFinancialMonthRange } from "@/utils/dateUtils";
 import { format } from "date-fns";
+import { AttributionPicker, type AttributionValue } from "@/components/shared/AttributionPicker";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 import { FormDialogFooter } from "@/components/shared/FormDialogFooter";
 import { FormField, FormRow } from "@/components/shared/FormField";
 import { useEntityForm } from "@/hooks/useEntityForm";
+import { oneOffExpenseCategories } from "@/constants/oneOffExpenseCategories";
 
-import { Wrench, Heart, Hammer, Gift, Plane, MoreHorizontal } from "lucide-react";
-
-const temporaryCategories = [
-    { value: "car_repair", label: "Car repair", icon: Wrench },
-    { value: "medical", label: "Medical", icon: Heart },
-    { value: "home_repair", label: "Home repair", icon: Hammer },
-    { value: "gift", label: "Gift", icon: Gift },
-    { value: "travel", label: "Travel", icon: Plane },
-    { value: "other", label: "Other", icon: MoreHorizontal },
-];
+interface InitialValues {
+    description?: string;
+    amount?: number | string;
+    category?: string;
+    notes?: string;
+    attribution?: AttributionValue;
+}
 
 interface TemporaryExpenseFormDialogProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
     householdId: string;
     financialMonthStart: number;
+    /** Pass the monthly_expenses row id to edit an existing one-off. */
+    editingId?: string;
+    initialValues?: InitialValues;
     onSuccess?: () => void;
 }
 
-const blank = () => ({
-    description: "",
-    amount: "",
-    category: "",
-    notes: "",
+const blank = (init?: InitialValues) => ({
+    description: init?.description ?? "",
+    amount: init?.amount != null ? String(init.amount) : "",
+    category: init?.category ?? "",
+    notes: init?.notes ?? "",
+    attribution: init?.attribution ?? null as AttributionValue,
 });
 
 export const TemporaryExpenseFormDialog = ({
-    open, onOpenChange, householdId, financialMonthStart, onSuccess,
+    open, onOpenChange, householdId, financialMonthStart, editingId, initialValues, onSuccess,
 }: TemporaryExpenseFormDialogProps) => {
     const { user } = useAuth();
     const { encryptRecord } = useEncryptedFields(monthlyExpenseFields);
-    const [pristine, setPristine] = useState(blank());
+    const [pristine, setPristine] = useState(() => blank(initialValues));
     const [formData, setFormData] = useState(pristine);
+    const isEdit = !!editingId;
 
     useEffect(() => {
         if (open) {
-            const b = blank();
+            const b = blank(initialValues);
             setPristine(b);
             setFormData(b);
         }
-    }, [open]);
+    }, [open, initialValues]);
 
     const canSave = !!formData.description.trim() && !!formData.amount.trim() && !!formData.category;
 
     const entityForm = useEntityForm({
         entityName: "One-time expense",
-        isEdit: false,
+        isEdit,
         save: async () => {
             if (!user) throw new Error("Not authenticated");
+            const subject_id = formData.attribution?.kind === "subject" ? formData.attribution.id : null;
+            const member_id = formData.attribution?.kind === "member" ? formData.attribution.id : null;
+            if (editingId) {
+                const data = await encryptRecord({ budget_snapshot: parseFloat(formData.amount) });
+                const { error } = await supabase
+                    .from("monthly_expenses")
+                    .update({
+                        ...data,
+                        one_time_name: formData.description.trim(),
+                        one_time_category: formData.category,
+                        notes: formData.notes || null,
+                        subject_id,
+                        member_id,
+                    } as any)
+                    .eq("id", editingId);
+                if (error) throw error;
+                return;
+            }
             const month = getCurrentFinancialMonth(financialMonthStart);
             const { start, end } = getFinancialMonthRange(month, financialMonthStart);
             const baseData = {
@@ -77,15 +100,25 @@ export const TemporaryExpenseFormDialog = ({
                 one_time_category: formData.category,
                 budget_snapshot: parseFloat(formData.amount),
                 notes: formData.notes || null,
+                subject_id,
+                member_id,
                 created_by: user.id,
             };
             const data = await encryptRecord(baseData);
             const { error } = await supabase.from("monthly_expenses").insert(data as any);
             if (error) throw error;
         },
+        remove: editingId ? async () => {
+            const { error } = await supabase.from("monthly_expenses").delete().eq("id", editingId);
+            if (error) throw error;
+        } : undefined,
         onSaved: () => {
             onSuccess?.();
-            if (!entityForm.createAnother) onOpenChange(false);
+            if (isEdit || !entityForm.createAnother) onOpenChange(false);
+        },
+        onDeleted: () => {
+            onSuccess?.();
+            onOpenChange(false);
         },
         resetForm: () => { const b = blank(); setPristine(b); setFormData(b); },
         formValues: formData,
@@ -96,7 +129,7 @@ export const TemporaryExpenseFormDialog = ({
         <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogContent>
                 <DialogHeader>
-                    <DialogTitle>Add one-off expense</DialogTitle>
+                    <DialogTitle>{isEdit ? "Edit one-off expense" : "Add one-off expense"}</DialogTitle>
                     <DialogDescription>
                         A one-time cost outside your regular budget — car repair, medical bill, gift, travel, etc.
                     </DialogDescription>
@@ -124,7 +157,7 @@ export const TemporaryExpenseFormDialog = ({
                             <Select value={formData.category} onValueChange={(v) => setFormData({ ...formData, category: v })}>
                                 <SelectTrigger><SelectValue placeholder="Select a category" /></SelectTrigger>
                                 <SelectContent>
-                                    {temporaryCategories.map((cat) => {
+                                    {oneOffExpenseCategories.map((cat) => {
                                         const Icon = cat.icon;
                                         return (
                                             <SelectItem key={cat.value} value={cat.value}>
@@ -140,6 +173,12 @@ export const TemporaryExpenseFormDialog = ({
                         </FormField>
                     </FormRow>
 
+                    <AttributionPicker
+                        householdId={householdId}
+                        value={formData.attribution ?? null}
+                        onChange={(attribution) => setFormData({ ...formData, attribution })}
+                    />
+
                     <FormField label="Notes" optional>
                         <Textarea
                             rows={2}
@@ -151,14 +190,25 @@ export const TemporaryExpenseFormDialog = ({
                 </div>
 
                 <FormDialogFooter
-                    isEdit={false}
+                    isEdit={isEdit}
                     saving={entityForm.saving}
+                    deleting={entityForm.deleting}
                     canSave={canSave && entityForm.isDirty}
                     onSave={entityForm.handleSave}
+                    onRequestDelete={editingId ? entityForm.requestDelete : undefined}
                     createAnother={entityForm.createAnother}
                     onCreateAnotherChange={entityForm.setCreateAnother}
                 />
             </DialogContent>
+
+            <ConfirmDialog
+                open={entityForm.confirmDeleteOpen}
+                onOpenChange={entityForm.setConfirmDeleteOpen}
+                title="Delete this one-off expense?"
+                description="This can't be undone."
+                busy={entityForm.deleting}
+                onConfirm={entityForm.handleDelete}
+            />
         </Dialog>
     );
 };

--- a/frontend/src/components/income/IncomeSourceItem.tsx
+++ b/frontend/src/components/income/IncomeSourceItem.tsx
@@ -1,4 +1,4 @@
-import { Pencil, Info, Sparkles } from "lucide-react";
+import { Pencil, Info, Sparkles, Split } from "lucide-react";
 import { getIncomeCategoryById } from "@/constants/incomeCategories";
 import { RowItem } from "@/components/ui/row-item";
 import { Money } from "@/components/ui/money";
@@ -42,9 +42,17 @@ export const IncomeSourceItem = ({
         >
             <div className="flex items-center gap-3 flex-1 min-w-0">
                 <CatIcon icon={Icon} hue={cat?.hue} size={32} />
-                <p className={`font-medium text-sm sm:text-base truncate ${isSkipped ? "line-through text-muted" : ""}`}>
-                    {(source.name || source.provider)}
-                </p>
+                <div className="flex items-center gap-2 min-w-0">
+                    <p className={`font-medium text-sm sm:text-base truncate ${isSkipped ? "line-through text-muted" : ""}`}>
+                        {(source.name || source.provider)}
+                    </p>
+                    {source.is_shared && (
+                        <span className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded bg-surface-2 text-muted shrink-0">
+                            <Split className="h-3 w-3" />
+                            Shared
+                        </span>
+                    )}
+                </div>
             </div>
 
             <div className="flex items-center gap-2 shrink-0">

--- a/frontend/src/components/shared/AttributionPicker.tsx
+++ b/frontend/src/components/shared/AttributionPicker.tsx
@@ -13,6 +13,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { useHouseholdSubjects, type SubjectType, type SubjectOption } from "@/hooks/useHouseholdSubjects";
 import { useAuth } from "@/contexts/AuthContext";
 import { useHousehold } from "@/contexts/HouseholdContext";
+import { shortMemberName } from "@/utils/memberName";
 
 export type AttributionValue =
     | { kind: "member"; id: string }
@@ -78,17 +79,10 @@ export const AttributionPicker = ({
 
     const sortedSubjects = subjects.slice().sort((a, b) => a.name.localeCompare(b.name));
 
-    // Last name shrunk to an initial so it fits the half-width "Covers" column on mobile.
-    const shortName = (full: string) => {
-        const parts = full.trim().split(/\s+/);
-        if (parts.length < 2) return parts[0] ?? "";
-        return `${parts[0]} ${parts[parts.length - 1][0]}`;
-    };
-
     const memberLabel = (m: typeof members[number]) => {
         const full = m.profiles?.full_name?.trim();
         if (!full) return m.user_id === user?.id ? "You" : "Unknown";
-        return shortName(full);
+        return shortMemberName(full);
     };
 
     return (

--- a/frontend/src/constants/oneOffExpenseCategories.ts
+++ b/frontend/src/constants/oneOffExpenseCategories.ts
@@ -1,0 +1,29 @@
+import { Wrench, Heart, Hammer, ShoppingBag, Gift, Plane, MoreHorizontal, LucideIcon } from "lucide-react";
+import { getCategoryById } from "./expenseCategories";
+
+export interface OneOffCategory {
+    value: string;
+    label: string;
+    icon: LucideIcon;
+    hue?: number;
+}
+
+export const oneOffExpenseCategories: OneOffCategory[] = [
+    { value: "car_repair", label: "Car repair", icon: Wrench, hue: 200 },
+    { value: "medical", label: "Medical", icon: Heart, hue: 150 },
+    { value: "home_repair", label: "Home repair", icon: Hammer, hue: 50 },
+    { value: "shopping", label: "Shopping", icon: ShoppingBag, hue: 320 },
+    { value: "gift", label: "Gift", icon: Gift, hue: 20 },
+    { value: "travel", label: "Travel", icon: Plane, hue: 200 },
+    { value: "other", label: "Other", icon: MoreHorizontal },
+];
+
+// A one-off value can come from the manual picker (above) OR credit-import,
+// whose values live in EXPENSE_CATEGORIES — fall through to that for icon/label.
+export const getOneOffCategory = (value?: string | null) => {
+    if (!value) return undefined;
+    const own = oneOffExpenseCategories.find(c => c.value === value);
+    if (own) return { icon: own.icon, hue: own.hue, label: own.label };
+    const expense = getCategoryById(value);
+    return expense ? { icon: expense.icon, hue: expense.hue, label: expense.label } : undefined;
+};

--- a/frontend/src/integrations/supabase/types.ts
+++ b/frontend/src/integrations/supabase/types.ts
@@ -1,4 +1,3 @@
-Initialising login role...
 export type Json =
   | string
   | number
@@ -714,12 +713,14 @@ export type Database = {
           id: string
           inactivated_at: string | null
           is_encrypted: boolean | null
+          member_id: string | null
           month: string
           month_end: string | null
           month_start: string | null
           notes: string | null
           one_time_category: string | null
           one_time_name: string | null
+          subject_id: string | null
           updated_at: string | null
         }
         Insert: {
@@ -737,12 +738,14 @@ export type Database = {
           id?: string
           inactivated_at?: string | null
           is_encrypted?: boolean | null
+          member_id?: string | null
           month: string
           month_end?: string | null
           month_start?: string | null
           notes?: string | null
           one_time_category?: string | null
           one_time_name?: string | null
+          subject_id?: string | null
           updated_at?: string | null
         }
         Update: {
@@ -760,12 +763,14 @@ export type Database = {
           id?: string
           inactivated_at?: string | null
           is_encrypted?: boolean | null
+          member_id?: string | null
           month?: string
           month_end?: string | null
           month_start?: string | null
           notes?: string | null
           one_time_category?: string | null
           one_time_name?: string | null
+          subject_id?: string | null
           updated_at?: string | null
         }
         Relationships: [
@@ -781,6 +786,20 @@ export type Database = {
             columns: ["household_id"]
             isOneToOne: false
             referencedRelation: "households"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "monthly_expenses_member_id_fkey"
+            columns: ["member_id"]
+            isOneToOne: false
+            referencedRelation: "household_members"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "monthly_expenses_subject_id_fkey"
+            columns: ["subject_id"]
+            isOneToOne: false
+            referencedRelation: "subjects"
             referencedColumns: ["id"]
           },
         ]
@@ -1544,6 +1563,10 @@ export type Database = {
     Functions: {
       confirm_member_exit: { Args: never; Returns: undefined }
       ensure_user_has_household: { Args: never; Returns: string }
+      financial_month_start_for: {
+        Args: { fms: number; reference_date: string }
+        Returns: string
+      }
       get_user_household_id: { Args: { _user_id: string }; Returns: string }
       handle_owner_leave: {
         Args: { successor_user_id_in: string }
@@ -1857,5 +1880,3 @@ export const Constants = {
     },
   },
 } as const
-A new version of Supabase CLI is available: v2.101.0 (currently installed v2.84.2)
-We recommend updating regularly for new features and bug fixes: https://supabase.com/docs/guides/cli/getting-started#updating-the-supabase-cli

--- a/frontend/src/pages/Expenses.tsx
+++ b/frontend/src/pages/Expenses.tsx
@@ -30,6 +30,7 @@ import { insuranceTypes } from "@/constants/insuranceTypes";
 import { VaultLockedAlert } from "@/components/shared/VaultLockedAlert";
 import { PastMonthDetailsDialog, PastMonthDetailsItem } from "@/components/shared/PastMonthDetailsDialog";
 import { getCategoryById } from "@/constants/expenseCategories";
+import { getOneOffCategory } from "@/constants/oneOffExpenseCategories";
 import { useEncryption } from "@/contexts/EncryptionContext";
 import { ExpensesPageSkeleton } from "@/components/shared/skeletons/PageSkeletons";
 import { AvatarTrigger } from "@/components/shared/AvatarTrigger";
@@ -37,6 +38,7 @@ import { UserMenu } from "@/components/shared/UserMenu";
 import { Skeleton } from "@/components/ui/skeleton";
 import { MobileBottomBar, mobileBottomBarSpacer } from "@/components/shared/MobileBottomBar";
 import { useHouseholdSubjects } from "@/hooks/useHouseholdSubjects";
+import { shortMemberName } from "@/utils/memberName";
 
 const Expenses = () => {
   const { user } = useAuth();
@@ -57,6 +59,7 @@ const Expenses = () => {
 
   const [editingSubscription, setEditingSubscription] = useState<any | null>(null);
   const [editingInsurance, setEditingInsurance] = useState<any | null>(null);
+  const [editingOneOff, setEditingOneOff] = useState<any | null>(null);
   const [detailsItem, setDetailsItem] = useState<PastMonthDetailsItem | null>(null);
 
   // ?expand=subscriptions|insurances|expenses picks which All-tab accordion
@@ -192,7 +195,6 @@ const Expenses = () => {
     setMonthlyExpenses(decryptedMonthly);
     setSubscriptions(decryptedSubs);
     setInsurances(decryptedIns);
-    // Credit card expenses now tracked via expenses.is_credit
 
     // Carry-forward: find most recent record per category (from any month before this one)
     const missingCategories = decryptedCategories.filter((cat: any) =>
@@ -478,7 +480,7 @@ const Expenses = () => {
                   actualAmount,
                   category: cat.category,
                   subject: subj ? { name: subj.name, type: subj.type } : undefined,
-                  member: mem ? { name: mem.profiles?.full_name ?? "Member" } : undefined,
+                  member: mem ? { name: shortMemberName(mem.profiles?.full_name ?? "Member") } : undefined,
                   isCredit: !!cat.is_credit,
                   previousBudgetSnapshot: monthly?.previous_budget_snapshot != null ? Number(monthly.previous_budget_snapshot) : undefined,
                   budgetChangedAt: monthly?.budget_changed_at ?? undefined,
@@ -486,23 +488,26 @@ const Expenses = () => {
                   inactivatedAt: monthly?.inactivated_at ?? undefined,
                 };
               }),
-              // One-time entries (e.g. from credit-import for un-budgeted
-              // categories). Source-less rows live only in the month they were
-              // charged; rendered read-only here so the user sees the history.
+              // One-off rows (manual or credit-import) have no expense source
+              // and live only in the month they were charged.
               ...monthlyExpenses
                 .filter((m: any) => m.expense_id == null && m.one_time_name)
                 .map((m: any) => {
                   const actualAmount = m.actual_amount != null ? Number(m.actual_amount) : undefined;
-                  // Past months: click opens Details. Current month: no edit
-                  // surface yet, so row stays non-interactive.
-                  const readOnly = !isPastMonth;
+                  const snapshot = m.budget_snapshot != null ? Number(m.budget_snapshot) : 0;
+                  const subj = subjects.find(s => s.id === m.subject_id);
+                  const mem = members.find(mm => mm.id === m.member_id);
+                  // Past months are read-only history; corrections go through Monthly Review.
+                  const readOnly = isPastMonth;
                   return {
                     id: `onetime-${m.id}`,
                     name: m.one_time_name as string,
-                    amount: actualAmount ?? 0,
+                    amount: actualAmount ?? snapshot,
                     budget: undefined,
                     actualAmount,
                     category: m.one_time_category as string | undefined,
+                    subject: subj ? { name: subj.name, type: subj.type } : undefined,
+                    member: mem ? { name: shortMemberName(mem.profiles?.full_name ?? "Member") } : undefined,
                     isOneOff: true,
                     readOnly,
                   };
@@ -521,7 +526,7 @@ const Expenses = () => {
                 isDue,
                 isDueNext,
                 subject: subj ? { name: subj.name, type: subj.type } : undefined,
-                member: mem ? { name: mem.profiles?.full_name ?? "Member" } : undefined,
+                member: mem ? { name: shortMemberName(mem.profiles?.full_name ?? "Member") } : undefined,
                 inactive: sub.is_active === false,
               };
             })}
@@ -554,7 +559,7 @@ const Expenses = () => {
                 isDue,
                 isDueNext,
                 subject: subj ? { name: subj.name, type: subj.type } : undefined,
-                member: mem ? { name: mem.profiles?.full_name ?? "Member" } : undefined,
+                member: mem ? { name: shortMemberName(mem.profiles?.full_name ?? "Member") } : undefined,
                 inactive: ins.is_active === false,
               };
             })}
@@ -567,11 +572,25 @@ const Expenses = () => {
             pastMonth={isPastMonth}
             onExpenseClick={(id) => {
               if (id.startsWith("onetime-")) {
-                if (!isPastMonth) return;
                 const monthlyId = id.slice("onetime-".length);
                 const monthly = monthlyExpenses.find((m: any) => m.id === monthlyId);
                 if (!monthly) return;
-                const cat = getCategoryById(monthly.one_time_category);
+                if (!isPastMonth) {
+                  setEditingOneOff({
+                    id: monthlyId,
+                    description: monthly.one_time_name ?? "",
+                    amount: monthly.budget_snapshot != null ? Number(monthly.budget_snapshot) : "",
+                    category: monthly.one_time_category ?? "",
+                    notes: monthly.notes ?? "",
+                    attribution: monthly.member_id
+                      ? { kind: "member", id: monthly.member_id }
+                      : monthly.subject_id
+                        ? { kind: "subject", id: monthly.subject_id }
+                        : null,
+                  });
+                  return;
+                }
+                const cat = getOneOffCategory(monthly.one_time_category);
                 setDetailsItem({
                   name: monthly.one_time_name,
                   categoryLabel: cat?.label,
@@ -603,7 +622,7 @@ const Expenses = () => {
                   actualRecordedAt: monthly?.actual_recorded_at ?? undefined,
                   inactivatedAt: monthly?.inactivated_at ?? undefined,
                   subject: subj ? { name: subj.name, type: subj.type } : undefined,
-                  member: mem ? { name: mem.profiles?.full_name ?? "Member" } : undefined,
+                  member: mem ? { name: shortMemberName(mem.profiles?.full_name ?? "Member") } : undefined,
                   isCredit: !!expense.is_credit,
                 });
                 return;
@@ -629,7 +648,7 @@ const Expenses = () => {
                   budget: parseFloat(String(subscription.budget || 0)),
                   billingLabel: cycleLabels[subscription.billing_cycle] || "/month",
                   subject: subj ? { name: subj.name, type: subj.type } : undefined,
-                  member: mem ? { name: mem.profiles?.full_name ?? "Member" } : undefined,
+                  member: mem ? { name: shortMemberName(mem.profiles?.full_name ?? "Member") } : undefined,
                 });
                 return;
               }
@@ -654,7 +673,7 @@ const Expenses = () => {
                   budget: parseFloat(String(insurance.budget || 0)),
                   billingLabel: cycleLabels[insurance.billing_cycle] || "/month",
                   subject: subj ? { name: subj.name, type: subj.type } : undefined,
-                  member: mem ? { name: mem.profiles?.full_name ?? "Member" } : undefined,
+                  member: mem ? { name: shortMemberName(mem.profiles?.full_name ?? "Member") } : undefined,
                 });
                 return;
               }
@@ -708,6 +727,18 @@ const Expenses = () => {
           onOpenChange={setAddTemporaryDialogOpen}
           householdId={household.id}
           financialMonthStart={financialMonthStart}
+          onSuccess={fetchData}
+        />
+      )}
+
+      {household && (
+        <TemporaryExpenseFormDialog
+          open={!!editingOneOff}
+          onOpenChange={(v) => { if (!v) setEditingOneOff(null); }}
+          householdId={household.id}
+          financialMonthStart={financialMonthStart}
+          editingId={editingOneOff?.id}
+          initialValues={editingOneOff ?? undefined}
           onSuccess={fetchData}
         />
       )}

--- a/frontend/src/pages/Income.tsx
+++ b/frontend/src/pages/Income.tsx
@@ -210,13 +210,22 @@ const Income = () => {
     setSourceDialogOpen(true);
   };
 
+  // Shared income only counts the household's own cut; the rest goes to the co-parent.
+  const shareFactor = (source: any): number =>
+    source.is_shared && source.share_percentage != null
+      ? Number(source.share_percentage) / 100
+      : 1;
+
   // Effective amount per source for display + totals.
   // Precedence: confirmed actual > frozen snapshot > current source.budget.
   const amountFor = (source: any): number => {
     const monthly = monthlyIncomes.find((m: any) => m.income_source_id === source.id);
-    if (monthly?.actual_amount != null) return Number(monthly.actual_amount);
-    if (monthly?.budget_snapshot != null) return Number(monthly.budget_snapshot);
-    return parseFloat((source.budget || "0").toString());
+    const raw = monthly?.actual_amount != null
+      ? Number(monthly.actual_amount)
+      : monthly?.budget_snapshot != null
+        ? Number(monthly.budget_snapshot)
+        : parseFloat((source.budget || "0").toString());
+    return raw * shareFactor(source);
   };
 
   const totalIncome = incomeSources.reduce((sum, s) => sum + amountFor(s), 0);
@@ -336,7 +345,7 @@ const Income = () => {
               const monthly = monthlyIncomes.find((m: any) => m.income_source_id === source.id);
               const rawActual = monthly?.actual_amount;
               const actualAmount = rawActual !== undefined && rawActual !== null
-                ? Number(rawActual)
+                ? Number(rawActual) * shareFactor(source)
                 : undefined;
 
               return (

--- a/frontend/src/pages/Overview.tsx
+++ b/frontend/src/pages/Overview.tsx
@@ -161,7 +161,7 @@ const Overview = () => {
       // monthly_* rows still contribute to totals.
       const isPastMonth = selectedMonth < todayMonth;
 
-      let incomeQuery = supabase.from("income_sources").select("id, encrypted_budget, is_encrypted").eq("household_id", household.id);
+      let incomeQuery = supabase.from("income_sources").select("id, encrypted_budget, is_encrypted, is_shared, share_percentage").eq("household_id", household.id);
       if (!isPastMonth) incomeQuery = incomeQuery.eq("is_active", true).is("archived_at", null);
 
       let expenseQuery = supabase.from("expenses").select("id, encrypted_budget, is_encrypted").eq("household_id", household.id);
@@ -257,7 +257,9 @@ const Overview = () => {
       };
 
       const recurringIncomeTotal = decryptedIncomeSources.reduce((sum: number, source: any) => {
-        return sum + resolveSourceAmount(source, monthlyByIncomeSource.get(source.id));
+        // Shared income only counts the household's own cut.
+        const shareRatio = source.is_shared ? (source.share_percentage || 50) / 100 : 1;
+        return sum + resolveSourceAmount(source, monthlyByIncomeSource.get(source.id)) * shareRatio;
       }, 0);
       const recurringExpensesTotal = decryptedExpenseSources.reduce((sum: number, source: any) => {
         return sum + resolveSourceAmount(source, monthlyByExpenseSource.get(source.id));

--- a/frontend/src/utils/memberName.ts
+++ b/frontend/src/utils/memberName.ts
@@ -1,0 +1,7 @@
+/** "Daniel Wahlgren" → "Daniel W". Single-word names are returned unchanged.
+ *  Members only — subjects (e.g. "Nya bilen") keep their full entered name. */
+export const shortMemberName = (full: string): string => {
+    const parts = full.trim().split(/\s+/).filter(Boolean);
+    if (parts.length < 2) return parts[0] ?? "";
+    return `${parts[0]} ${parts[parts.length - 1][0]}`;
+};

--- a/supabase/migrations/20260524100000_monthly_expenses_attribution.sql
+++ b/supabase/migrations/20260524100000_monthly_expenses_attribution.sql
@@ -1,0 +1,10 @@
+-- One-off expenses live only in monthly_expenses (no parent expenses row), so
+-- they had nowhere to store a "Belongs to" tag. Mirror the attribution columns
+-- the source tables already carry: exactly one of {member_id, subject_id}.
+-- ON DELETE SET NULL so removing a member/subject untags rather than deletes.
+
+ALTER TABLE public.monthly_expenses
+    ADD COLUMN IF NOT EXISTS subject_id uuid REFERENCES public.subjects(id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS member_id uuid REFERENCES public.household_members(id) ON DELETE SET NULL,
+    ADD CONSTRAINT monthly_expenses_one_attribution
+        CHECK (member_id IS NULL OR subject_id IS NULL);


### PR DESCRIPTION
Second dogfooding batch. **Migration already applied to the DB** (`20260524100000`), types regenerated via `supabase gen types`.

## One-off expenses
- Show the actual amount (was rendering 0 kr — read from `budget_snapshot`, not just `actual_amount`).
- Current-month one-offs are now editable + deletable (`TemporaryExpenseFormDialog` gained edit/delete mode); past months stay read-only history.
- **Belongs to** (member/subject) attribution added — new nullable `subject_id`/`member_id` on `monthly_expenses` (mirrors the source tables). Badge shows in the list.
- Added **Shopping** to the one-off picker.
- Fixed wrong icons for manual-only categories (medical/home_repair) — one-offs now resolve icons from their own vocab, falling back to expense categories for credit-import values.

## Shared income
- Shared income now counts only the household's own share (`share_percentage`) in both the Income page and the Overview totals — previously the full amount was counted.
- Added a **Shared** badge to shared income rows.

## Display
- Member names shortened to "Daniel W" in chips + the attribution picker (shared `shortMemberName` util). Subjects keep their full names.

## Deferred (separate discussion)
Enum-ifying `one_time_category` and the recurring-vs-one-off category model are intentionally **not** in this PR — see notes; the one-off vocab is still partly coupled to recurring category metadata.