### PR TITLE
Settlement income share fix, Income one-off button, DevTools typing

### DIFF
--- a/frontend/src/components/dev/DevTools.tsx
+++ b/frontend/src/components/dev/DevTools.tsx
@@ -9,6 +9,7 @@ import { useHousehold } from "@/contexts/HouseholdContext";
 import { useEncryption } from "@/contexts/EncryptionContext";
 import { getCurrentFinancialMonth, formatFinancialMonth } from "@/utils/dateUtils";
 import { supabase } from "@/integrations/supabase/client";
+import type { TablesInsert } from "@/integrations/supabase/types";
 import { toast } from "sonner";
 
 // Sensitive (encrypted) fields per source table: plaintext key → encrypted column.
@@ -75,8 +76,8 @@ export const DevTools = () => {
             if (error) throw error;
             toast.success("Review state reset");
             window.location.reload();
-        } catch (e: any) {
-            toast.error(e.message || "Failed to reset review state");
+        } catch (e) {
+            toast.error(e instanceof Error ? e.message : "Failed to reset review state");
         } finally {
             setBusy(false);
         }
@@ -103,19 +104,19 @@ export const DevTools = () => {
             const memberUserById = new Map((members || []).map(m => [m.id, m.user_id]));
 
             // Decrypt sensitive columns → plaintext, keep structural, drop env-specific.
-            const pack = async (rows: any[] | null, table: string) => {
+            const pack = async (rows: Record<string, unknown>[] | null, table: string) => {
                 const sens = SENSITIVE[table];
                 const struct = STRUCTURAL[table];
                 return Promise.all((rows || []).map(async (row) => {
-                    const out: Record<string, any> = { id: row.id };
+                    const out: Record<string, unknown> = { id: row.id };
                     for (const key of struct) out[key] = row[key] ?? null;
                     for (const [plain, enc] of Object.entries(sens)) {
-                        out[plain] = row[enc] ? await decrypt(row[enc]) : null;
+                        out[plain] = row[enc] ? await decrypt(row[enc] as string) : null;
                     }
                     if (table === "income_sources") out.owner_id = row.owner_id;
                     // member_id → resolve to user_id so import can remap into the new household.
                     if ("member_id" in row && row.member_id) {
-                        out._member_user_id = memberUserById.get(row.member_id) ?? null;
+                        out._member_user_id = memberUserById.get(row.member_id as string) ?? null;
                     }
                     return out;
                 }));
@@ -125,13 +126,13 @@ export const DevTools = () => {
                 version: EXPORT_VERSION,
                 exportedAt: new Date().toISOString(),
                 household: { name: household.name, currency: household.currency, financial_month_start: financialMonthStart },
-                subjects: (subjects.data || []).map((s: any) => ({ id: s.id, name: s.name, type: s.type, sort_order: s.sort_order, user_id: s.user_id })),
-                co_parents: (coParents.data || []).map((c: any) => ({ id: c.id, name: c.name, notes: c.notes })),
-                income_sources: await pack(incomes.data, "income_sources"),
-                expenses: await pack(expenses.data, "expenses"),
-                subscriptions: await pack(subs.data, "subscriptions"),
-                insurances: await pack(insurances.data, "insurances"),
-                credit_cards: await pack(cards.data, "credit_cards"),
+                subjects: (subjects.data || []).map((s) => ({ id: s.id, name: s.name, type: s.type, sort_order: s.sort_order, user_id: s.user_id })),
+                co_parents: (coParents.data || []).map((c) => ({ id: c.id, name: c.name, notes: c.notes })),
+                income_sources: await pack(incomes.data as Record<string, unknown>[] | null, "income_sources"),
+                expenses: await pack(expenses.data as Record<string, unknown>[] | null, "expenses"),
+                subscriptions: await pack(subs.data as Record<string, unknown>[] | null, "subscriptions"),
+                insurances: await pack(insurances.data as Record<string, unknown>[] | null, "insurances"),
+                credit_cards: await pack(cards.data as Record<string, unknown>[] | null, "credit_cards"),
             };
 
             const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
@@ -142,9 +143,9 @@ export const DevTools = () => {
             a.click();
             URL.revokeObjectURL(url);
             toast.success("Exported financial data");
-        } catch (err: any) {
+        } catch (err) {
             console.error("Export failed:", err);
-            toast.error(err?.message || "Export failed");
+            toast.error(err instanceof Error ? err.message : "Export failed");
         } finally {
             setBusy(false);
         }
@@ -184,7 +185,7 @@ export const DevTools = () => {
             const cardMap = new Map<string, string>();
             for (const c of data.credit_cards || []) {
                 const row = await encryptRow(c, "credit_cards", { household_id: hid, created_by: uid, is_active: c.is_active ?? true });
-                const { data: inserted, error } = await supabase.from("credit_cards").insert(row).select("id").single();
+                const { data: inserted, error } = await supabase.from("credit_cards").insert(row as TablesInsert<"credit_cards">).select("id").single();
                 if (error) throw error;
                 cardMap.set(c.id, inserted.id);
             }
@@ -192,7 +193,7 @@ export const DevTools = () => {
             // user_id → current household_members.id, for member attribution remap.
             const memberIdByUser = new Map((members || []).map(m => [m.user_id, m.id]));
             const validUserIds = new Set((members || []).map(m => m.user_id));
-            const remapMember = (item: any) => item._member_user_id ? (memberIdByUser.get(item._member_user_id) ?? null) : null;
+            const remapMember = (item: Record<string, unknown>) => item._member_user_id ? (memberIdByUser.get(item._member_user_id as string) ?? null) : null;
 
             // 2. Income sources.
             for (const it of data.income_sources || []) {
@@ -208,7 +209,7 @@ export const DevTools = () => {
                     custom_tax_rate: it.custom_tax_rate ?? null,
                     category: it.category,
                 });
-                const { error } = await supabase.from("income_sources").insert(row);
+                const { error } = await supabase.from("income_sources").insert(row as TablesInsert<"income_sources">);
                 if (error) throw error;
             }
 
@@ -227,7 +228,7 @@ export const DevTools = () => {
                     metadata: it.metadata ?? null,
                     icon: it.icon ?? null,
                 });
-                const { error } = await supabase.from("expenses").insert(row);
+                const { error } = await supabase.from("expenses").insert(row as TablesInsert<"expenses">);
                 if (error) throw error;
             }
 
@@ -244,7 +245,7 @@ export const DevTools = () => {
                     subject_id: it.subject_id ? (subjectMap.get(it.subject_id) ?? null) : null,
                     member_id: remapMember(it),
                 });
-                const { error } = await supabase.from("subscriptions").insert(row);
+                const { error } = await supabase.from("subscriptions").insert(row as TablesInsert<"subscriptions">);
                 if (error) throw error;
             }
 
@@ -264,23 +265,23 @@ export const DevTools = () => {
                     subject_id: it.subject_id ? (subjectMap.get(it.subject_id) ?? null) : null,
                     member_id: remapMember(it),
                 });
-                const { error } = await supabase.from("insurances").insert(row);
+                const { error } = await supabase.from("insurances").insert(row as TablesInsert<"insurances">);
                 if (error) throw error;
             }
 
             toast.success("Imported — reloading…");
             setTimeout(() => window.location.reload(), 800);
-        } catch (err: any) {
+        } catch (err) {
             console.error("Import failed:", err);
-            toast.error(err?.message || "Import failed");
+            toast.error(err instanceof Error ? err.message : "Import failed");
         } finally {
             setBusy(false);
         }
     };
 
     // Encrypt the sensitive fields of an item and merge with the structural base.
-    const encryptRow = async (item: any, table: string, base: Record<string, any>) => {
-        const row: Record<string, any> = { ...base, is_encrypted: true };
+    const encryptRow = async (item: Record<string, unknown>, table: string, base: Record<string, unknown>) => {
+        const row: Record<string, unknown> = { ...base, is_encrypted: true };
         for (const [plain, enc] of Object.entries(SENSITIVE[table])) {
             const value = item[plain];
             row[enc] = (value !== undefined && value !== null && value !== "")

--- a/frontend/src/components/dev/DevTools.tsx
+++ b/frontend/src/components/dev/DevTools.tsx
@@ -58,6 +58,30 @@ export const DevTools = () => {
         window.location.reload();
     };
 
+    // Time-travel testing can finalize a review for a month that hasn't really
+    // started yet, leaving a monthly_review_finalized row that suppresses the
+    // banner once real time catches up. This wipes review state so it re-shows.
+    const handleResetReview = async () => {
+        if (!household) {
+            toast.error("No household");
+            return;
+        }
+        setBusy(true);
+        try {
+            const { error } = await supabase
+                .from("monthly_review_finalized")
+                .delete()
+                .eq("household_id", household.id);
+            if (error) throw error;
+            toast.success("Review state reset");
+            window.location.reload();
+        } catch (e: any) {
+            toast.error(e.message || "Failed to reset review state");
+        } finally {
+            setBusy(false);
+        }
+    };
+
     const handleExport = async () => {
         if (!household || !isUnlocked) {
             toast.error("Unlock the vault first");
@@ -298,6 +322,15 @@ export const DevTools = () => {
                                 </Button>
                             )}
                         </div>
+                    </div>
+
+                    {/* Review state */}
+                    <div className="space-y-2 border-t border-line pt-3">
+                        <Label className="text-xs text-ink">Review state</Label>
+                        <p className="text-[11px] text-muted">Clears finalized reviews so the banner re-shows. Fixes time-travel pollution.</p>
+                        <Button size="sm" variant="outline" disabled={busy} onClick={handleResetReview} className="w-full h-8">
+                            <RotateCcw className="h-3.5 w-3.5 mr-1.5" /> Reset review state
+                        </Button>
                     </div>
 
                     {/* Data export / import */}

--- a/frontend/src/components/income/OneTimeIncomeDialog.tsx
+++ b/frontend/src/components/income/OneTimeIncomeDialog.tsx
@@ -27,9 +27,10 @@ const oneTimeCategories = [
 interface OneTimeIncomeDialogProps {
     householdId: string;
     onSuccess: () => void;
+    disabled?: boolean;
 }
 
-export const OneTimeIncomeDialog = ({ householdId, onSuccess }: OneTimeIncomeDialogProps) => {
+export const OneTimeIncomeDialog = ({ householdId, onSuccess, disabled = false }: OneTimeIncomeDialogProps) => {
     const { user } = useAuth();
     const { financialMonthStart } = useHousehold();
     const { toast } = useToast();
@@ -91,7 +92,7 @@ export const OneTimeIncomeDialog = ({ householdId, onSuccess }: OneTimeIncomeDia
     return (
         <Dialog open={isOpen} onOpenChange={(open) => { setIsOpen(open); if (!open) resetForm(); }}>
             <DialogTrigger asChild>
-                <Button variant="outline" size="lg" className="w-full justify-center gap-2">
+                <Button variant="outline" size="lg" disabled={disabled} className="w-full justify-center gap-2">
                     <Gift className="h-4 w-4" />
                     One-off
                 </Button>

--- a/frontend/src/hooks/useCoParentSettlements.ts
+++ b/frontend/src/hooks/useCoParentSettlements.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { format } from "date-fns";
 import { supabase } from "@/integrations/supabase/client";
 import { getCurrentFinancialMonth, getFinancialMonthRange } from "@/utils/dateUtils";
-import { useEncryptedFields, monthlyIncomeFields, monthlyInsuranceFields, insuranceFields, sharedExpenseFields } from "@/hooks/useEncryptedFields";
+import { useEncryptedFields, monthlyIncomeFields, monthlyInsuranceFields, insuranceFields, incomeSourceFields, sharedExpenseFields } from "@/hooks/useEncryptedFields";
 import { billsInFinancialMonth } from "@/utils/billingEvents";
 
 export interface CoParentSettlement {
@@ -25,6 +25,7 @@ export function useCoParentSettlements({ householdId, coParents, financialMonthS
     const [settlements, setSettlements] = useState<Record<string, CoParentSettlement>>({});
 
     const { decryptRecords: decryptIncomes } = useEncryptedFields(monthlyIncomeFields);
+    const { decryptRecords: decryptIncomeSources } = useEncryptedFields(incomeSourceFields);
     const { decryptRecords: decryptInsurances } = useEncryptedFields(monthlyInsuranceFields);
     const { decryptRecords: decryptInsuranceSources } = useEncryptedFields(insuranceFields);
     const { decryptRecords: decryptShared } = useEncryptedFields(sharedExpenseFields);
@@ -41,15 +42,23 @@ export function useCoParentSettlements({ householdId, coParents, financialMonthS
         const monthEndStr = format(monthEnd, "yyyy-MM-dd");
         const coParentIds = coParents.map(cp => cp.id);
 
-        const [incomesResult, insSourcesResult, monthlyInsResult, expensesResult] = await Promise.all([
+        const [incSourcesResult, monthlyIncResult, insSourcesResult, monthlyInsResult, expensesResult] = await Promise.all([
+            // Shared income sources are the truth for shared-ness; monthly_incomes
+            // only overrides the per-month amount (mirrors the insurance handling).
+            supabase
+                .from("income_sources")
+                .select("id, share_percentage, co_parent_id, encrypted_budget, is_encrypted")
+                .eq("household_id", householdId)
+                .eq("is_shared", true)
+                .eq("is_active", true)
+                .is("archived_at", null)
+                .in("co_parent_id", coParentIds),
             supabase
                 .from("monthly_incomes")
-                .select("encrypted_budget_snapshot, encrypted_actual_amount, share_percentage, is_encrypted, co_parent_id")
+                .select("income_source_id, encrypted_budget_snapshot, encrypted_actual_amount, is_encrypted")
                 .eq("household_id", householdId)
                 .gte("month_end", monthStartStr)
-                .lte("month_start", monthEndStr)
-                .eq("is_shared", true)
-                .in("co_parent_id", coParentIds),
+                .lte("month_start", monthEndStr),
             // Shared insurances (source rows) — used to determine which bill in current FM via date-math.
             supabase
                 .from("insurances")
@@ -75,7 +84,8 @@ export function useCoParentSettlements({ householdId, coParents, financialMonthS
                 .lte("month_start", monthEndStr),
         ]);
 
-        const decryptedIncomes = (await decryptIncomes(incomesResult.data || [])) as any[];
+        const decryptedIncSources = (await decryptIncomeSources(incSourcesResult.data || [])) as any[];
+        const decryptedMonthlyInc = (await decryptIncomes(monthlyIncResult.data || [])) as any[];
         const decryptedInsSources = (await decryptInsuranceSources(insSourcesResult.data || [])) as any[];
         const decryptedMonthlyIns = (await decryptInsurances(monthlyInsResult.data || [])) as any[];
         const decryptedExpenses = (await decryptShared(expensesResult.data || [])) as any[];
@@ -83,7 +93,7 @@ export function useCoParentSettlements({ householdId, coParents, financialMonthS
         const next: Record<string, CoParentSettlement> = {};
 
         for (const coParent of coParents) {
-            const sharedIncomes = decryptedIncomes.filter(r => r.co_parent_id === coParent.id);
+            const sharedIncomeSources = decryptedIncSources.filter((s: any) => s.co_parent_id === coParent.id);
             // Shared insurances bill in current FM (date-math), with actual-or-budget fallback.
             const sharedInsuranceSources = decryptedInsSources.filter(
                 (s: any) => s.co_parent_id === coParent.id
@@ -91,11 +101,19 @@ export function useCoParentSettlements({ householdId, coParents, financialMonthS
             );
             const sharedExpenses = decryptedExpenses.filter(r => r.co_parent_id === coParent.id);
 
-            const incomeReceived = sharedIncomes.reduce((sum, inc) => sum + parseFloat(((inc.actual_amount ?? inc.budget_snapshot) || 0).toString()), 0);
-            const yourShareOfIncome = sharedIncomes.reduce((sum, inc) => {
-                const sharePercentage = parseFloat((inc.share_percentage || 0).toString());
-                return sum + (parseFloat(((inc.actual_amount ?? inc.budget_snapshot) || 0).toString()) * sharePercentage / 100);
-            }, 0);
+            // Amount from the month's snapshot/actual, falling back to source.budget;
+            // share % is the source's (the snapshot doesn't carry it).
+            let incomeReceived = 0;
+            let yourShareOfIncome = 0;
+            sharedIncomeSources.forEach((source: any) => {
+                const monthly = decryptedMonthlyInc.find((m: any) => m.income_source_id === source.id);
+                const amount = parseFloat(
+                    ((monthly?.actual_amount ?? monthly?.budget_snapshot ?? source.budget) || 0).toString(),
+                );
+                const sharePercentage = parseFloat((source.share_percentage || 0).toString());
+                incomeReceived += amount;
+                yourShareOfIncome += amount * sharePercentage / 100;
+            });
 
             let insurancePaid = 0;
             let theirShareOfInsurance = 0;

--- a/frontend/src/pages/Income.tsx
+++ b/frontend/src/pages/Income.tsx
@@ -318,7 +318,7 @@ const Income = () => {
             <Plus className="h-4 w-4" />
             Add source
           </Button>
-          {!isReadOnly && <OneTimeIncomeDialog householdId={household.id} onSuccess={fetchData} />}
+          <OneTimeIncomeDialog householdId={household.id} onSuccess={fetchData} disabled={isReadOnly} />
         </div>
       )}
 
@@ -377,7 +377,7 @@ const Income = () => {
             <Plus className="h-4 w-4" />
             Add source
           </Button>
-          {!isReadOnly && <OneTimeIncomeDialog householdId={household.id} onSuccess={fetchData} />}
+          <OneTimeIncomeDialog householdId={household.id} onSuccess={fetchData} disabled={isReadOnly} />
         </MobileBottomBar>
       )}
 


### PR DESCRIPTION
Dogfooding fixes batch (staging → main).

## Fixes
- **Co-parent settlement showed 0 kr for shared income.** The hook read shared-ness (`is_shared`/`co_parent_id`/`share_percentage`) from the `monthly_incomes` snapshot, which is seeded with only `budget_snapshot`. Now reads share %/co-parent from `income_sources` (the source of truth) and uses `monthly_incomes` only for the per-month amount — mirroring how insurances already work in the same hook. The "X shares" card now reflects the real balance.
- **Income "One-off" button vanished when the page was review-gated**, unlike Expenses where both buttons stay visible-but-disabled. `OneTimeIncomeDialog` now accepts `disabled`; both Income action rows render it always, disabled when read-only.
- **DevTools.tsx typing** — replaced `any` with `Record<string, unknown>`, typed catch clauses, and cast dynamic inserts to `TablesInsert<...>`. eslint + tsc clean.

No migrations in this batch.