### PR TITLE
Fix invoice-parse API URL; reset-review-state cleanup

### DIFF
--- a/frontend/src/components/dev/DevTools.tsx
+++ b/frontend/src/components/dev/DevTools.tsx
@@ -59,9 +59,10 @@ export const DevTools = () => {
         window.location.reload();
     };
 
-    // Time-travel testing can finalize a review for a month that hasn't really
-    // started yet, leaving a monthly_review_finalized row that suppresses the
-    // banner once real time catches up. This wipes review state so it re-shows.
+    // Reset the current FM's review to a fresh state. Recurring monthly rows
+    // reseed from their source on next page load, so deleting this-FM-onward
+    // drops any stale snapshot/actuals from time-travel testing. Source items,
+    // one-off rows (no source link), and all past months are left untouched.
     const handleResetReview = async () => {
         if (!household) {
             toast.error("No household");
@@ -69,12 +70,19 @@ export const DevTools = () => {
         }
         setBusy(true);
         try {
-            const { error } = await supabase
-                .from("monthly_review_finalized")
-                .delete()
-                .eq("household_id", household.id);
-            if (error) throw error;
-            toast.success("Review state reset");
+            const hid = household.id;
+            const month = getCurrentFinancialMonth(financialMonthStart);
+            const results = await Promise.all([
+                supabase.from("monthly_review_finalized").delete().eq("household_id", hid).gte("month", month),
+                supabase.from("monthly_review_status").delete().eq("household_id", hid).gte("month", month),
+                supabase.from("monthly_incomes").delete().eq("household_id", hid).gte("month", month).not("income_source_id", "is", null),
+                supabase.from("monthly_expenses").delete().eq("household_id", hid).gte("month", month).not("expense_id", "is", null),
+                supabase.from("monthly_subscriptions").delete().eq("household_id", hid).gte("month", month),
+                supabase.from("monthly_insurances").delete().eq("household_id", hid).gte("month", month),
+            ]);
+            const failed = results.find(r => r.error)?.error;
+            if (failed) throw failed;
+            toast.success("Review state reset — reseeds from your items on reload");
             window.location.reload();
         } catch (e) {
             toast.error(e instanceof Error ? e.message : "Failed to reset review state");
@@ -328,7 +336,7 @@ export const DevTools = () => {
                     {/* Review state */}
                     <div className="space-y-2 border-t border-line pt-3">
                         <Label className="text-xs text-ink">Review state</Label>
-                        <p className="text-[11px] text-muted">Clears finalized reviews so the banner re-shows. Fixes time-travel pollution.</p>
+                        <p className="text-[11px] text-muted">Deletes this month's recurring monthly rows (reseed from items) + step/finalize state. Keeps sources, one-offs, past months.</p>
                         <Button size="sm" variant="outline" disabled={busy} onClick={handleResetReview} className="w-full h-8">
                             <RotateCcw className="h-3.5 w-3.5 mr-1.5" /> Reset review state
                         </Button>

--- a/frontend/src/components/overview/ImportStatementStep.tsx
+++ b/frontend/src/components/overview/ImportStatementStep.tsx
@@ -24,7 +24,7 @@ interface ParseResult {
     cached: boolean;
 }
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || "";
+const API_BASE_URL = import.meta.env.VITE_BACKEND_URL || "";
 
 interface ImportStatementStepProps {
     householdId: string;


### PR DESCRIPTION
Two fixes for the Monthly Review flow (staging → main).

## fix(review): invoice parse hit the wrong host
`ImportStatementStep` was the only file reading `VITE_API_URL`; the rest of the app uses `VITE_BACKEND_URL`. `VITE_API_URL` isn't set on Vercel, so the credit-PDF upload POSTed to the Vercel domain (`/api/llm/parse-invoice`) instead of the Railway backend → SPA rewrite → **405**. Now uses `VITE_BACKEND_URL` (already configured), so it reaches the real FastAPI route. No Vercel env change needed.

## feat(dev): "Reset review state" now reseeds monthly rows
Time-travel testing can freeze a future FM's test actuals into the current month's `budget_snapshot` (rows are seeded on page-load, not at finalize), leaving spurious variance + pre-accepted steps. The DEV-only reset now deletes — scoped to the current FM onward, this household — the finalize/status rows and the source-linked recurring `monthly_incomes`/`monthly_expenses` + `monthly_subscriptions`/`monthly_insurances`, so they reseed from the source items. Leaves source items, one-off rows, and all past months untouched.

No migrations.