### PR TITLE
Add Home & appliances + Treats & comfort expense categories

### DIFF
--- a/frontend/src/constants/expenseCategories.ts
+++ b/frontend/src/constants/expenseCategories.ts
@@ -1,4 +1,4 @@
-import { Home, Wifi, Smartphone, Zap, ShoppingCart, UtensilsCrossed, Film, ShoppingBag, Fuel, Wrench, CreditCard, Heart, Sparkles, Plane, Users2, GraduationCap, LucideIcon } from "lucide-react";
+import { Home, Wifi, Smartphone, Zap, ShoppingCart, UtensilsCrossed, Film, ShoppingBag, Fuel, Wrench, CreditCard, Heart, Sparkles, Plane, Users2, GraduationCap, Sofa, Candy, LucideIcon } from "lucide-react";
 
 export interface ExpenseCategory {
     id: string;
@@ -34,6 +34,8 @@ export const EXPENSE_CATEGORIES: ExpenseCategory[] = [
     { id: 'healthcare', label: 'Healthcare', icon: Heart, hue: 150 },
     { id: 'memberships', label: 'Memberships & dues', icon: Users2, hue: 100 },
     { id: 'childcare', label: 'Childcare & school', icon: GraduationCap, hue: 20 },
+    { id: 'home_appliances', label: 'Home & appliances', icon: Sofa, hue: 40 },
+    { id: 'treats_comfort', label: 'Treats & comfort', icon: Candy, hue: 340, isBudgeted: true },
     { id: 'other', label: 'Other', icon: Sparkles },
 ];
 

--- a/frontend/src/integrations/supabase/types.ts
+++ b/frontend/src/integrations/supabase/types.ts
@@ -1615,6 +1615,8 @@ export type Database = {
         | "healthcare"
         | "memberships"
         | "childcare"
+        | "home_appliances"
+        | "treats_comfort"
         | "other"
       household_role: "owner" | "member"
       income_category:
@@ -1816,6 +1818,8 @@ export const Constants = {
         "healthcare",
         "memberships",
         "childcare",
+        "home_appliances",
+        "treats_comfort",
         "other",
       ],
       household_role: ["owner", "member"],

--- a/supabase/migrations/20260526100000_add_home_appliances_treats_comfort_categories.sql
+++ b/supabase/migrations/20260526100000_add_home_appliances_treats_comfort_categories.sql
@@ -1,0 +1,6 @@
+-- Two new expense categories: "Home & appliances" (furniture/appliances split
+-- out from Shopping) and "Treats & comfort" (alcohol, nicotine, kiosk treats).
+-- Positioned before 'other' to mirror the frontend ordering.
+
+ALTER TYPE public.expense_category_enum ADD VALUE IF NOT EXISTS 'home_appliances' BEFORE 'other';
+ALTER TYPE public.expense_category_enum ADD VALUE IF NOT EXISTS 'treats_comfort' BEFORE 'other';


### PR DESCRIPTION
Two new expense categories (migration already applied to the live DB; types regenerated via supabase gen types).

- **Home & appliances** (`home_appliances`) — furniture/appliances, split out from Shopping for cleaner insight.
- **Treats & comfort** (`treats_comfort`) — alcohol, nicotine, kiosk treats; marked budgeted (estimate treatment).

No further DB push needed.