### PR TITLE
Show profile photo in desktop sidebar

### DIFF
--- a/frontend/src/components/DesktopNav.tsx
+++ b/frontend/src/components/DesktopNav.tsx
@@ -3,6 +3,8 @@ import { NavLink } from "./NavLink";
 import { useAuth } from "@/contexts/AuthContext";
 import { useHousehold } from "@/contexts/HouseholdContext";
 import { UserMenu } from "./shared/UserMenu";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { initialsOf } from "@/utils/memberName";
 
 const DesktopNav = () => {
   const { user } = useAuth();
@@ -11,7 +13,8 @@ const DesktopNav = () => {
   const me = members.find(m => m.user_id === user?.id);
   const fullName = me?.profiles?.full_name || "";
   const firstName = fullName.trim().split(/\s+/)[0] || "";
-  const initial = firstName.charAt(0).toUpperCase() || "·";
+  const avatarUrl = me?.profiles?.avatar_url || null;
+  const initials = initialsOf(fullName);
 
   const navItems = [
     { icon: Home, label: "Overview", path: "/" },
@@ -62,9 +65,12 @@ const DesktopNav = () => {
                 className="w-full rounded-[12px] bg-surface-2 p-3 flex items-center gap-2.5 hover:bg-accent-tint hover:text-accent-dk transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
                 aria-label="Account menu"
               >
-                <span className="w-8 h-8 rounded-full bg-accent text-accent-ink flex items-center justify-center font-bold text-[13px] shrink-0">
-                  {initial}
-                </span>
+                <Avatar className="w-8 h-8 shrink-0">
+                  <AvatarImage src={avatarUrl || undefined} alt={fullName || "User"} />
+                  <AvatarFallback className="bg-accent text-accent-ink font-bold text-[13px]">
+                    {initials}
+                  </AvatarFallback>
+                </Avatar>
                 <span className="flex-1 min-w-0 text-left">
                   <span className="block text-[13px] font-semibold text-ink truncate">{firstName}</span>
                 </span>

--- a/frontend/src/components/shared/AvatarTrigger.tsx
+++ b/frontend/src/components/shared/AvatarTrigger.tsx
@@ -2,6 +2,7 @@ import { forwardRef } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useHousehold } from "@/contexts/HouseholdContext";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { initialsOf } from "@/utils/memberName";
 import { cn } from "@/lib/utils";
 
 interface AvatarTriggerProps {
@@ -9,13 +10,6 @@ interface AvatarTriggerProps {
     className?: string;
     onClick?: () => void;
 }
-
-const initialsOf = (fullName: string) => {
-    const parts = fullName.trim().split(/\s+/).filter(Boolean);
-    if (parts.length === 0) return "·";
-    if (parts.length === 1) return parts[0].charAt(0).toUpperCase();
-    return (parts[0].charAt(0) + parts[parts.length - 1].charAt(0)).toUpperCase();
-};
 
 /**
  * Round avatar button: profile photo when set, initials otherwise. Anchors the

--- a/frontend/src/utils/memberName.ts
+++ b/frontend/src/utils/memberName.ts
@@ -5,3 +5,11 @@ export const shortMemberName = (full: string): string => {
     if (parts.length < 2) return parts[0] ?? "";
     return `${parts[0]} ${parts[parts.length - 1][0]}`;
 };
+
+/** "Daniel Wahlgren" → "DW". Avatar fallback when there's no photo. */
+export const initialsOf = (full: string): string => {
+    const parts = full.trim().split(/\s+/).filter(Boolean);
+    if (parts.length === 0) return "·";
+    if (parts.length === 1) return parts[0].charAt(0).toUpperCase();
+    return (parts[0].charAt(0) + parts[parts.length - 1].charAt(0)).toUpperCase();
+};


### PR DESCRIPTION
The desktop sidebar's user card showed a plain green single-initial circle while the mobile top-right shows the real avatar. Now the sidebar uses the same `Avatar` (photo + two-initial fallback). Extracted `initialsOf` to `utils/memberName` so the sidebar and `AvatarTrigger` share one source of truth.